### PR TITLE
Fix Alert Page Error

### DIFF
--- a/apps/server/src/server/api/zodSchemas/alert.schema.ts
+++ b/apps/server/src/server/api/zodSchemas/alert.schema.ts
@@ -1,7 +1,16 @@
 import {z} from 'zod';
 
+import validator from 'validator';
+
+export const idSchema = z.string().min(1, { message: "ID must be 1 or more characters long" }).max(100, { message: "ID be 100 or less characters long" }).refine(value => {
+        const sanitized = validator.escape(value);
+        return sanitized === value;
+}, {
+    message: 'Invalid ID',
+});
+
 export const queryAlertSchema = z.object({
-    id: z.string().cuid({ message: "Invalid ID" }).or(z.string().uuid({ message: "Invalid ID" })),
+    id: idSchema,
 })
 
 


### PR DESCRIPTION
Zod library gave errors in production code. Removed .cuid() or .uuid() from code and replaced it to use Validator to sanitize the Alert Id. 