### PR TITLE
Improved performance for geo-event-fetcher cronjob

### DIFF
--- a/apps/server/src/Services/GeoEvent/GeoEventHandler.ts
+++ b/apps/server/src/Services/GeoEvent/GeoEventHandler.ts
@@ -68,7 +68,7 @@ const processGeoEvents = async (breadcrumbPrefix: string, geoEventProviderClient
   };
 
   const filteredDuplicateNewGeoEvents = filterDuplicateEvents(newGeoEvents)
-  logger(`${breadcrumbPrefix} Found ${filteredDuplicateNewGeoEvents.length} new Geo Events`, "info");
+  const countFilteredDuplicateNewGeoEvents = filteredDuplicateNewGeoEvents.length
 
   let geoEventsCreated = 0;
   // Create new GeoEvents in the database
@@ -96,7 +96,7 @@ const processGeoEvents = async (breadcrumbPrefix: string, geoEventProviderClient
     // Repeat until all chunks have been inserted
     // Return the number of GeoEvents created
 
-    const bulkSize = 20000;
+    const bulkSize = 1000;
     for (let i = 0; i < geoEventsToBeCreated.length; i += bulkSize) {
       const chunk = geoEventsToBeCreated.slice(i, i + bulkSize);
       await prisma.geoEvent.createMany({
@@ -105,12 +105,9 @@ const processGeoEvents = async (breadcrumbPrefix: string, geoEventProviderClient
       });
       geoEventsCreated += chunk.length;
     }
-
-    logger(`${breadcrumbPrefix} Created ${geoEventsCreated} Geo Events`, "info");
-
   }
 
-  return geoEventsCreated;
+  return {geoEventCount: geoEventsCreated, newGeoEventCount: countFilteredDuplicateNewGeoEvents}
 };
 
 export default processGeoEvents;

--- a/apps/server/src/Services/GeoEventProvider/ProviderClass/NasaGeoEventProviderClass.ts
+++ b/apps/server/src/Services/GeoEventProvider/ProviderClass/NasaGeoEventProviderClass.ts
@@ -109,6 +109,11 @@ class NasaGeoEventProviderClass implements GeoEventProviderClass {
                         while (record = parser.read()) {
                             records.push(normalize(record, record.instrument));
                             recordCount++;
+                            // Handle Stream Backpressure
+                            if(recordCount % 1000 === 0){ // after every 1000 records
+                                parser.pause(); // pause the stream
+                                setTimeout(()=> parser.resume(),0) // schedule resume in next tick
+                            }
                         }
                     })
                     .on("end", () => {

--- a/apps/server/src/Services/GeoEventProvider/ProviderClass/NasaGeoEventProviderClass.ts
+++ b/apps/server/src/Services/GeoEventProvider/ProviderClass/NasaGeoEventProviderClass.ts
@@ -98,6 +98,7 @@ class NasaGeoEventProviderClass implements GeoEventProviderClass {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 const csv = await response.text();
+
                 const parser = parse(csv, { columns: true });
 
                 const records: GeoEvent[] = [];


### PR DESCRIPTION
The `getLatestGeoEvents `function experienced difficulties when processing large CSV files containing over 20,000 geoEvents. The root cause of this issue was identified as stream backpressure.

Problem:
We utilize the `csv-parse` library to read CSV data, which inherently operates using streams. If there's a prolonged processing time for the incoming data while reading, the underlying stream buffer can reach its limit. This can lead to backpressure, which in turn can result in the stream producing errors or halting altogether. With the volume of geoEvents we handle, this issue became particularly pronounced.

Solution:
To mitigate this problem, a backpressure management strategy was implemented. We now pause the stream after every 1000 records processed, giving the system a breather. To ensure efficient processing and not hinder overall performance, we resume the stream in the next event loop tick.