### PR TITLE
Enhanced SMS Handling and Country SMS Restrictions

### DIFF
--- a/apps/server/src/pages/api/tests/sms.ts
+++ b/apps/server/src/pages/api/tests/sms.ts
@@ -1,3 +1,4 @@
+// Call this api to run this page: http://localhost:3000/api/tests/sms?phoneNumber="encoded-phone-number"
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { logger } from "../../../../src/server/logger";
 import NotifierRegistry from "../../../Services/Notifier/NotifierRegistry";

--- a/apps/server/src/pages/api/tests/sms.ts
+++ b/apps/server/src/pages/api/tests/sms.ts
@@ -1,0 +1,47 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { logger } from "../../../../src/server/logger";
+import NotifierRegistry from "../../../Services/Notifier/NotifierRegistry";
+import { NotificationParameters } from "../../../Interfaces/NotificationParameters"; // Adjust this import path if necessary
+
+export default async function testSms(req: NextApiRequest, res: NextApiResponse) {
+    logger(`Running Test SMS Sender.`, "info");
+
+    // Extract the phone number from the query parameters
+    const destination = req.query['phoneNumber'] as string;
+    if (!destination) {
+        return res.status(400).json({
+            message: "Error: Phone number is required.",
+            status: "400",
+        });
+    }
+
+    // Create the notification parameters
+    const notificationParameters: NotificationParameters = {
+        message: "Test Message from Fire Alert",
+        subject: "Test Message",
+    };
+
+    try {
+        // Use the NotifierRegistry to get the SMS notifier
+        const notifier = NotifierRegistry.get('sms');
+        const isDelivered = await notifier.notify(destination, notificationParameters);
+        
+        if (isDelivered) {
+            res.status(200).json({
+                message: "SMS Sent Successfully!",
+                status: "200",
+            });
+        } else {
+            res.status(500).json({
+                message: "Failed to send SMS.",
+                status: "500",
+            });
+        }
+    } catch (error) {
+        logger(`Error sending test SMS: ${error}`, "error");
+        res.status(500).json({
+            message: `Error sending SMS`,
+            status: "500",
+        });
+    }
+}

--- a/apps/server/src/server/api/routers/alertMethod.ts
+++ b/apps/server/src/server/api/routers/alertMethod.ts
@@ -20,6 +20,7 @@ import {
     deviceVerification
 } from "../../../utils/routers/alertMethod";
 import { logger } from "../../../../src/server/logger";
+import { isPhoneNumberRestricted } from "../../../../src/utils/notification/restrictedSMS";
 
 export const alertMethodRouter = createTRPCRouter({
 
@@ -64,7 +65,17 @@ export const alertMethodRouter = createTRPCRouter({
         .input(verifySchema)
         .mutation(async ({ ctx, input }) => {
             const alertMethodId = input.params.alertMethodId
-            await findAlertMethod(alertMethodId)
+            const alertMethod = await findAlertMethod(alertMethodId)
+            const destination = alertMethod.destination
+            const method = alertMethod.method
+            if(method === 'sms'){
+                if (isPhoneNumberRestricted(destination)) {
+                    throw new TRPCError({
+                        code: 'UNAUTHORIZED',
+                        message: `Cannot Verify AlertMethod. ${destination} is restricted due to country limitations.`,
+                    });
+                }
+            }
             const verificatonRequest = await findVerificationRequest(alertMethodId)
             const currentTime = new Date();
             // TODO: Also check if it is expired or not, by checking if the verificationRequest.expires is less than the time right now, if yes, set isExpired to true.

--- a/apps/server/src/utils/notification/restrictedSMS.ts
+++ b/apps/server/src/utils/notification/restrictedSMS.ts
@@ -1,0 +1,24 @@
+// Checks if any destination phone number string falls among the restrictedCountries area code, 
+// if yes, return true, else false 
+
+import phone from 'phone';
+
+const restrictedCountryCodes = [
+    'RU', // Russia
+    'TJ', // Tajikistan
+    'MG', // Madagascar
+    'ID', // Indonesia
+    'PK', // Pakistan
+    'AZ', // Azerbaijan
+    'PS', // Palestinian Territory
+    'LY', // Libya
+    'UZ', // Uzbekistan
+    'AF', // Afghanistan
+    'BZ', // Belize
+];
+
+export const isPhoneNumberRestricted = (phoneNumber: string) => {
+    const phoneResult = phone(phoneNumber);
+    const countryCode = phoneResult.countryIso2 as string;
+    return restrictedCountryCodes.includes(countryCode);
+}


### PR DESCRIPTION
In this PR, I have made significant improvements to our SMS error handling mechanism and introduced certain restrictions.

**### Changes:**

**### Twilio Error Code Handling:**
We've enhanced the handling of specific Twilio error codes to improve the reliability of our SMS notifications. Here's a breakdown:

**21610, 30005, 21408, and 21211:** These error codes relate to issues such as the recipient using the "STOP" keyword, the destination number being unknown/inactive, permissions not being enabled for certain regions, and invalid "To" phone numbers. When any of these errors are encountered, the associated Alert Method is disabled.

**30008, 30007, 30006, and 30003:** These codes signify problems like unknown delivery failures, policy violations, attempts to send SMS to landlines, and unreachable destination handsets. When we detect these errors, they are logged for further analysis, but the Alert Method is not disabled.

**### Test-SMS API Route:**
Introduced a new test API route test-sms that allows sending test SMS messages.
This route accepts an URL-encoded phone number as a query parameter and sends an SMS to the provided number.

**### Create and Verify AlertMethod, Send SMS Restrictions:**
Implemented restrictions on creating and verifying the sms alertMethod for certain countries due to SMS limitations.
Added checks in the SMS sending mechanism to ensure that SMS messages are not sent to restricted phone numbers. 
Here's the list of countries for which we have restricted SMS service:
Russia, Tajikistan, Madagascar, Indonesia, Pakistan, Azerbaijan, Palestinian Territory, Libya, Uzbekistan, Afghanistan, Belize.
