### PR TITLE
Basic and Custom Plan, Limit Specific Alert Methods based on Plans

### DIFF
--- a/apps/server/prisma/migrations/20231016000000_user_plan_and_detection_area/migration.sql
+++ b/apps/server/prisma/migrations/20231016000000_user_plan_and_detection_area/migration.sql
@@ -1,0 +1,7 @@
+-- Add plan column on User table
+ALTER TABLE "User"
+ADD COLUMN "plan" TEXT NOT NULL DEFAULT 'basic';
+
+-- Add detectionArea column in Site table
+ALTER TABLE "Site"
+ADD COLUMN "detectionArea" DOUBLE PRECISION DEFAULT 0;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
     emailVerified    Boolean       @default(false)
     detectionMethods Json // ["MODIS","VIIRS","LANDSAT","GEOSTATIONARY"]
     isPlanetRO       Boolean?
+    plan             String        @default("basic") //"basic" or "custom"
     image            String?
     deletedAt        DateTime?
     isVerified       Boolean?
@@ -43,7 +44,7 @@ model VerificationRequest {
 
 model AlertMethod {
     id                  String               @id @default(cuid())
-    method              String
+    method              String  //"email","sms","webhook","device","whatsapp"
     destination         String
     isVerified          Boolean              @default(false)
     isEnabled           Boolean              @default(false)

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -44,7 +44,7 @@ model VerificationRequest {
 
 model AlertMethod {
     id                  String               @id @default(cuid())
-    method              String  //"email","sms","webhook","device","whatsapp"
+    method              String  
     destination         String
     isVerified          Boolean              @default(false)
     isEnabled           Boolean              @default(false)
@@ -77,6 +77,7 @@ model Site {
     slices            Json? // Will be something like ["1","2"] or ["3"] or ["1"] or ["7","8"]
     detectionGeometry Unsupported("geometry")?
     originalGeometry  Unsupported("geometry")?
+    detectionArea     Float?
     alerts            SiteAlert[]
     project           Project?                 @relation(fields: [projectId], references: [id])
     user              User                     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/server/src/Interfaces/AlertMethod.ts
+++ b/apps/server/src/Interfaces/AlertMethod.ts
@@ -28,8 +28,24 @@ export type CtxWithAlertMethodId = {
   alertMethodId: string;
 };
 
-export type CtxWithUserID = {
+export type LimitAlertMethods = {
   ctx: TRPCContext;
   userId: string;
   count: number;
+};
+
+export type LimitSpecificAlertMethods = {
+  ctx: TRPCContext;
+  userId: string;
+  count: number;
+  method: string;
+};
+
+export type UserPlan = 'basic' | 'custom';
+
+export type LimitAlertMethodBasedOnPlanProps = {
+  ctx: TRPCContext;
+  userId: string;
+  userPlan: UserPlan;
+  method: string;
 };

--- a/apps/server/src/server/api/routers/alertMethod.ts
+++ b/apps/server/src/server/api/routers/alertMethod.ts
@@ -158,7 +158,16 @@ export const alertMethodRouter = createTRPCRouter({
             }
             // If existing alertMethod doesn't exist:
             // Check if the user has reached the maximum limit of alert methods for all alertMethods (e.g., 5)
-            await limitAlertMethodBasedOnPlan({ctx, userId, userPlan: userPlan, method: input.method});
+            const limitAlertMethod = await limitAlertMethodBasedOnPlan({ctx, userId, userPlan: userPlan, method: input.method});
+            
+            // If AlertMethod Limit has been reached, we get status.error response.
+            // If status is 'error' return with the error message, httpStatus, and code.
+            // If status is not 'error', continue with createAlertMethod logic
+            if(limitAlertMethod?.status === 'error'){
+                return{
+                    ...limitAlertMethod
+                }
+            }
 
             // If the alertMethod method is device then try deviceVerification, if it fails, throw an error, if it succeds create alertMethod
 

--- a/apps/server/src/server/api/routers/alertMethod.ts
+++ b/apps/server/src/server/api/routers/alertMethod.ts
@@ -1,4 +1,4 @@
-import { TRPCError } from "@trpc/server";
+import {TRPCError} from "@trpc/server";
 import {
     createAlertMethodSchema,
     params,
@@ -13,21 +13,22 @@ import {
 import {
     findAlertMethod,
     findVerificationRequest,
-    limitAlertMethodPerUser,
     checkUserHasAlertMethodPermission,
     returnAlertMethod,
     handlePendingVerification,
-    deviceVerification
+    deviceVerification,
+    limitAlertMethodBasedOnPlan
 } from "../../../utils/routers/alertMethod";
-import { logger } from "../../../../src/server/logger";
-import { isPhoneNumberRestricted } from "../../../../src/utils/notification/restrictedSMS";
+import {logger} from "../../../../src/server/logger";
+import {isPhoneNumberRestricted} from "../../../../src/utils/notification/restrictedSMS";
+import {UserPlan} from "../../../../src/Interfaces/AlertMethod";
 
 export const alertMethodRouter = createTRPCRouter({
 
     //Todo: Abstract the functions in SendVerification and createAlertMethod to a separate file so that it can be reused in the verify function.
     sendVerification: protectedProcedure
         .input(params)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
             try {
                 const alertMethodId = input.alertMethodId
@@ -63,7 +64,7 @@ export const alertMethodRouter = createTRPCRouter({
 
     verify: publicProcedure
         .input(verifySchema)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ctx, input}) => {
             const alertMethodId = input.params.alertMethodId
             const alertMethod = await findAlertMethod(alertMethodId)
             const destination = alertMethod.destination
@@ -120,8 +121,9 @@ export const alertMethodRouter = createTRPCRouter({
 
     createAlertMethod: protectedProcedure
         .input(createAlertMethodSchema)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
+            const userPlan = ctx.user!.plan ? ctx.user!.plan as UserPlan : 'basic';
             //Check if that AlertMethod already exists
             const existingAlertMethod = await ctx.prisma.alertMethod.findFirst({
                 where: {
@@ -155,8 +157,8 @@ export const alertMethodRouter = createTRPCRouter({
                 };
             }
             // If existing alertMethod doesn't exist:
-            // Check if the user has reached the maximum limit of alert methods (e.g., 5)
-            await limitAlertMethodPerUser({ ctx, userId: userId, count: 10 })
+            // Check if the user has reached the maximum limit of alert methods for all alertMethods (e.g., 5)
+            await limitAlertMethodBasedOnPlan({ctx, userId, userPlan: userPlan, method: input.method});
 
             // If the alertMethod method is device then try deviceVerification, if it fails, throw an error, if it succeds create alertMethod
 
@@ -252,7 +254,7 @@ export const alertMethodRouter = createTRPCRouter({
         }),
 
     getAlertMethods: protectedProcedure
-        .query(async ({ ctx }) => {
+        .query(async ({ctx}) => {
             const userId = ctx.user!.id;
             try {
                 const alertMethods = await ctx.prisma.alertMethod.findMany({
@@ -292,9 +294,9 @@ export const alertMethodRouter = createTRPCRouter({
 
     getAlertMethod: protectedProcedure
         .input(params)
-        .query(async ({ ctx, input }) => {
+        .query(async ({ctx, input}) => {
             const userId = ctx.user!.id;
-            const existingAlertMethod = await checkUserHasAlertMethodPermission({ ctx, alertMethodId: input.alertMethodId, userId: userId });
+            const existingAlertMethod = await checkUserHasAlertMethodPermission({ctx, alertMethodId: input.alertMethodId, userId: userId});
             if (existingAlertMethod.deletedAt) {
                 throw new TRPCError({
                     code: "FORBIDDEN",
@@ -325,9 +327,9 @@ export const alertMethodRouter = createTRPCRouter({
 
     updateAlertMethod: protectedProcedure
         .input(updateAlertMethodSchema)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
-            const existingAlertMethod = await checkUserHasAlertMethodPermission({ ctx, alertMethodId: input.params.alertMethodId, userId: userId });
+            const existingAlertMethod = await checkUserHasAlertMethodPermission({ctx, alertMethodId: input.params.alertMethodId, userId: userId});
             if (existingAlertMethod.deletedAt) {
                 throw new TRPCError({
                     code: "BAD_REQUEST",
@@ -368,9 +370,9 @@ export const alertMethodRouter = createTRPCRouter({
 
     deleteAlertMethod: protectedProcedure
         .input(params)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
-            const existingAlertMethod = await checkUserHasAlertMethodPermission({ ctx, alertMethodId: input.alertMethodId, userId: userId });
+            const existingAlertMethod = await checkUserHasAlertMethodPermission({ctx, alertMethodId: input.alertMethodId, userId: userId});
             if (existingAlertMethod.deletedAt) {
                 return {
                     status: "success",

--- a/apps/server/src/server/api/routers/site.ts
+++ b/apps/server/src/server/api/routers/site.ts
@@ -14,32 +14,32 @@ export const siteRouter = createTRPCRouter({
         .input(createSiteSchema)
         .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
-            const userPlan = ctx.user!.plan ? ctx.user!.plan as UserPlan : 'basic';
-            const siteCount = await ctx.prisma.site.count({
-                where:{
-                    userId,
-                }
-            })
-            if(userPlan === 'basic'){
-                if (siteCount >= 20){
-                    return {
-                        status: 'error',
-                        httpStatus: 403,
-                        code: 'FORBIDDEN',
-                        message: `You've exceeded the fair site use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`,
-                    };
-                }
-            }
-            if(userPlan === 'custom'){
-                if (siteCount >= 50){
-                    return {
-                        status: 'error',
-                        httpStatus: 403,
-                        code: 'FORBIDDEN',
-                        message: `You've exceeded the fair site use limits of FireAlert. You cannot create any more sites.`,
-                    };
-                }
-            }
+            // const userPlan = ctx.user!.plan ? ctx.user!.plan as UserPlan : 'basic';
+            // const siteCount = await ctx.prisma.site.count({
+            //     where:{
+            //         userId,
+            //     }
+            // })
+            // if(userPlan === 'basic'){
+            //     if (siteCount >= 20){
+            //         return {
+            //             status: 'error',
+            //             httpStatus: 403,
+            //             code: 'FORBIDDEN',
+            //             message: `You've exceeded the fair site use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`,
+            //         };
+            //     }
+            // }
+            // if(userPlan === 'custom'){
+            //     if (siteCount >= 50){
+            //         return {
+            //             status: 'error',
+            //             httpStatus: 403,
+            //             code: 'FORBIDDEN',
+            //             message: `You've exceeded the fair site use limits of FireAlert. You cannot create any more sites.`,
+            //         };
+            //     }
+            // }
             try {
                 const origin = 'firealert';
                 const lastUpdated = new Date();

--- a/apps/server/src/utils/routers/alertMethod.ts
+++ b/apps/server/src/utils/routers/alertMethod.ts
@@ -29,13 +29,14 @@ export const limitSpecificAlertMethodPerUser = async ({
       method
     },
   });
-
   if (specificAlertMethodCount >= count) {
-    throw new TRPCError({
+    return {
+      httpStatus: 403,
       code: 'FORBIDDEN',
       message: `You've exceeded the fair ${method} use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`,
-    });
-  }
+    };
+  };
+  return null;
 };
 
 export const limitAlertMethodBasedOnPlan = async (props: LimitAlertMethodBasedOnPlanProps) => {
@@ -78,8 +79,18 @@ export const limitAlertMethodBasedOnPlan = async (props: LimitAlertMethodBasedOn
               return; // Or handle any other cases as required
       }
   }
-
-  await limitSpecificAlertMethodPerUser({ctx, userId, count: countLimit, method});
+  const errorResponse =  await limitSpecificAlertMethodPerUser({ctx, userId, count: countLimit, method});
+  // If errorResponse is not null
+  if(errorResponse){
+    return{
+      ...errorResponse,
+      status: 'error'
+    }
+  }else{
+    return{
+      status: 'success'
+    }
+  }
 };
 
 

--- a/apps/server/src/utils/routers/alertMethod.ts
+++ b/apps/server/src/utils/routers/alertMethod.ts
@@ -3,7 +3,8 @@ import {type TRPCContext} from '../../Interfaces/Context';
 import {
   type CheckUserHasAlertMethodPermissionArgs,
   type CtxWithAlertMethod,
-  type CtxWithUserID,
+  type LimitSpecificAlertMethods,
+  type LimitAlertMethodBasedOnPlanProps,
 } from '../../Interfaces/AlertMethod';
 import {generate5DigitOTP} from '../notification/otp';
 import {
@@ -16,23 +17,72 @@ import NotifierRegistry from '../../Services/Notifier/NotifierRegistry';
 import {prisma} from '../../server/db';
 import {sendEmailVerificationCode} from '../notification/userEmails';
 
-export const limitAlertMethodPerUser = async ({
+export const limitSpecificAlertMethodPerUser = async ({
   ctx,
   userId,
   count,
-}: CtxWithUserID) => {
-  const alertMethodCount = await ctx.prisma.alertMethod.count({
+  method
+}: LimitSpecificAlertMethods) => {
+  const specificAlertMethodCount = await ctx.prisma.alertMethod.count({
     where: {
       userId,
+      method
     },
   });
-  if (alertMethodCount >= count) {
-    return {
-      status: 403,
-      message: 'Exceeded maximum alert methods limit',
-    };
+
+  if (specificAlertMethodCount >= count) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: `You've exceeded the fair ${method} use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`,
+    });
   }
 };
+
+export const limitAlertMethodBasedOnPlan = async (props: LimitAlertMethodBasedOnPlanProps) => {
+  const {ctx, userId, userPlan, method} = props;
+  
+  let countLimit = 0;
+
+  if(userPlan === 'basic') {
+      switch (method) {
+          case 'email':
+              countLimit = 20;
+              break;
+          case 'sms':
+              countLimit = 5;
+              break;
+          case 'webhook':
+              countLimit = 20;
+              break;
+          case 'whatsapp':
+              countLimit = 5;
+              break;
+          default:
+              return; // Or handle any other cases as required
+      }
+  } else if (userPlan === 'custom') {
+      switch (method) {
+          case 'email':
+              countLimit = 50;
+              break;
+          case 'sms':
+              countLimit = 10;
+              break;
+          case 'webhook':
+              countLimit = 50;
+              break;
+          case 'whatsapp':
+              countLimit = 10;
+              break;
+          default:
+              return; // Or handle any other cases as required
+      }
+  }
+
+  await limitSpecificAlertMethodPerUser({ctx, userId, count: countLimit, method});
+};
+
+
 
 // Compares the User in session or token with the AlertMethod that is being Read, Updated or Deleted
 export const checkUserHasAlertMethodPermission = async ({


### PR DESCRIPTION
## **Features**

1. **User Plan System**: Add a plan to the user schema to categorize users as either "basic" or "custom".
2. **Limit Alert Methods**: Based on the user's plan, impose restrictions on the number of specific alert methods they can create. Once this limit is exceeded, the user is shown 403 `FORBIDDEN` error with an error message: “`You've exceeded the fair ${method} use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`"