### PR TITLE
Hotfix/fix notification bug

### DIFF
--- a/apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts
+++ b/apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts
@@ -2,11 +2,33 @@ import {type NotificationParameters} from '../../../Interfaces/NotificationParam
 import type Notifier from '../Notifier';
 import {NOTIFICATION_METHOD} from '../methodConstants';
 import {env} from '../../../env.mjs';
-import {logger} from '../../../../src/server/logger';
+import {logger} from '../../../server/logger';
+import {prisma} from '../../../server/db';
 
 class DeviceNotifier implements Notifier {
   getSupportedMethods(): Array<string> {
     return [NOTIFICATION_METHOD.DEVICE];
+  }
+
+  async deleteNotificationAndDevice(destination: string, notificationId: string): Promise<void> {
+    try {
+      // Delete the notification
+      await prisma.notification.delete({
+        where: {
+          id: notificationId,
+        },
+      });
+      // Unverify and disable the alertMethod
+      await prisma.alertMethod.deleteMany({
+        where: {
+          destination: destination,
+          method: NOTIFICATION_METHOD.DEVICE,
+        }
+      });
+      logger(`Notification with ID: ${notificationId} deleted and alertMethod for destination: ${destination} has been unverified and disabled.`, "info");
+    } catch (error) {
+      logger(`Database Error: Couldn't modify the alertMethod or delete the notification: ${error}`, "error");
+    }
   }
 
   // OneSignal can send both iOS and android notifications,
@@ -46,6 +68,10 @@ class DeviceNotifier implements Notifier {
         `Failed to send device notification. Error: ${response.statusText} for ${parameters.id}`,
         'error',
       );
+      // If device not found
+      if(response.status === 404){
+        await this.deleteNotificationAndDevice(destination, parameters.id)
+      }
       return false;
     }
 

--- a/apps/server/src/Services/Notifier/Notifier/WebhookNotifier.ts
+++ b/apps/server/src/Services/Notifier/Notifier/WebhookNotifier.ts
@@ -1,3 +1,4 @@
+import {prisma} from '../../../server/db';
 import {logger} from '../../../../src/server/logger';
 import {type NotificationParameters} from '../../../Interfaces/NotificationParameters';
 import type Notifier from '../Notifier';
@@ -6,6 +7,31 @@ import {NOTIFICATION_METHOD} from '../methodConstants';
 class WebhookNotifier implements Notifier {
   getSupportedMethods(): Array<string> {
     return [NOTIFICATION_METHOD.WEBHOOK];
+  }
+
+  async deleteNotificationDisableAndUnverifyWebhook(destination: string, notificationId: string): Promise<void> {
+    try {
+      // Delete the notification
+      await prisma.notification.delete({
+        where: {
+          id: notificationId,
+        },
+      });
+      // Unverify and disable the alertMethod
+      await prisma.alertMethod.updateMany({
+        where: {
+          destination: destination,
+          method: NOTIFICATION_METHOD.WEBHOOK,
+        },
+        data: {
+          isVerified: false,
+          isEnabled: false,
+        },
+      });
+      logger(`Notification with ID: ${notificationId} deleted and alertMethod for destination: ${destination} has been unverified and disabled.`, "info");
+    } catch (error) {
+      logger(`Database Error: Couldn't modify the alertMethod or delete the notification: ${error}`, "error");
+    }
   }
 
   async notify(
@@ -34,12 +60,27 @@ class WebhookNotifier implements Notifier {
 
     if (!response.ok) {
       logger(
-        `Failed to send webhook notification. Error: ${response.statusText}  for ${parameters.id}`,
+        `Failed to send webhook notification. Error: ${response.statusText}  for ${parameters.id}.`,
         'error',
       );
+      // Specific status code handling
+      if (response.status === 404) {
+        // Webhook URL Not Found - Token not found
+        await this.deleteNotificationDisableAndUnverifyWebhook(destination, parameters.id);
+      } else if (response.status === 401){
+        // Unauthorized
+        await this.deleteNotificationDisableAndUnverifyWebhook(destination, parameters.id);
+      } else if (response.status === 403){
+        // Forbidden
+        await this.deleteNotificationDisableAndUnverifyWebhook(destination, parameters.id);
+      } else {
+        logger(
+          `Failed to send webhook notification. Something went wrong. Try again in next run.`,
+          'error',
+        );
+      }
       return false;
     }
-
     return true;
   }
 }

--- a/apps/server/src/server/api/zodSchemas/alertMethod.schema.ts
+++ b/apps/server/src/server/api/zodSchemas/alertMethod.schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import {z} from 'zod';
 import phone from 'phone'
 import validator from 'validator';
 
@@ -6,26 +6,29 @@ export const createAlertMethodSchema = z.object({
     method: z.enum(["email", "sms", "device", "whatsapp", "webhook"]),
     destination: z.string({
         required_error: 'Destination of alert method must be specified'
-    }).refine((value) => {
-            const sanitized = validator.escape(value);
-            return sanitized === value;
-        }, {
-            message: 'Contains invalid characters',
-        }),
+    }),
     deviceName: z.string().optional(),
     deviceId: z.string().optional(),
 }).refine((obj) => {
-    if (obj.method === 'sms') {
-        // Check if the destination is a valid phone number in E.164 format
-        const { isValid } = phone(obj.destination);
-        return isValid;
+    if(obj.method === 'webhook'){
+        return true;
+    }else{
+        const sanitized = validator.escape(obj.destination);
+        if (sanitized !== obj.destination){
+            return false;
+        }
+        if (obj.method === 'sms') {
+            // Check if the destination is a valid phone number in E.164 format
+            const { isValid } = phone(obj.destination);
+            return isValid;
+        }
+        if (obj.method === 'email') {
+            return z.string().email().safeParse(obj.destination).success;
+        }
+        return true; // Return true for other methods
     }
-    if (obj.method === 'email') {
-        return z.string().email().safeParse(obj.destination).success;
-    }
-    return true; // Return true for other methods
 }, {
-    message: 'Must be a valid phone number in E.164 format when the method is "sms"'
+    message: `Invalid Destination`
 });
 
 export const params = z.object({


### PR DESCRIPTION
Error Handling in Webhook Notifier and Device Notifier. 

For WebhookNotifier, If the response status is 404, 401 and 403, we delete the notification while disabling and unverifying the alertMethod.

For DeviceNotifier, if the response status is 404, we delete notification and alertMethod.
