### PR TITLE
Increase maxDuration for geo-event-fetcher to 5 minutes

### DIFF
--- a/apps/server/src/pages/api/cron/geo-event-fetcher.ts
+++ b/apps/server/src/pages/api/cron/geo-event-fetcher.ts
@@ -16,7 +16,7 @@ import { type geoEventInterface as GeoEvent } from "../../../Interfaces/GeoEvent
 // This ensures that the alertFetcher Vercel serverless function runs for a maximum of 300 seconds
 // 300s is the maximum allowed duration for Vercel pro plans
 export const config = {
-  maxDuration: 60,
+  maxDuration: 300,
 };
 
 // TODO: Run this cron every 5 minutes


### PR DESCRIPTION
Currently, our alert fetcher system has SERVERLESS_TIMEOUT error. This fix increases the maxDuration to 5 minute to deal with the issue temporarily.