### PR TITLE
Fix db-cleanup

### DIFF
--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -9,7 +9,7 @@ import { sendAccountDeletionConfirmationEmail } from "../../../../src/utils/noti
 // Run this cron every day once for max 60s.
 export const config = {
     maxDuration: 60,
-  };
+};
 
 // This cron will also help with GDPR compliance and data retention.
 
@@ -92,7 +92,7 @@ export default async function dbCleanup(req: NextApiRequest, res: NextApiRespons
     // Delete all SiteAlerts that have deletedAt date older than 30 days
     promises.push(prisma.siteAlert.deleteMany({
         where: {
-            deletedAt: {
+            eventDate: {
                 lte: new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000)
             }
         }

--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -89,6 +89,16 @@ export default async function dbCleanup(req: NextApiRequest, res: NextApiRespons
     }));
 
     // item 4:
+    // Delete all AlertMethods that have been soft-deleteted for longer than 7 days
+    promises.push(prisma.alertMethod.deleteMany({
+        where: {
+            deletedAt: {
+                lte: new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000)
+            }
+        }
+    }))
+
+    // item 5:
     // Delete all SiteAlerts that have deletedAt date older than 30 days
     promises.push(prisma.siteAlert.deleteMany({
         where: {
@@ -102,13 +112,14 @@ export default async function dbCleanup(req: NextApiRequest, res: NextApiRespons
 
     try {
 
-        const [deletedGeoEvent, deletedUsers, deletedSites, deletedSiteAlerts] =
+        const [deletedGeoEvents, deletedUsers, deletedSites, deletedAlertMethods, deletedSiteAlerts] =
             await Promise.all(promises);
         
         logger(`
-                Deleted ${deletedGeoEvent.count} geo events that are older than 30 days and have been processed
+                Deleted ${deletedGeoEvents.count} geo events that are older than 30 days and have been processed
                 Deleted ${deletedUsers.count} users who've requested to be deleted and have deletedAt date older than 7 days
                 Deleted ${deletedSites.count} soft-deleted Sites
+                Deleted ${deletedAlertMethods.count} soft-deleted AlertMethods
                 Deleted ${deletedSiteAlerts.count} soft-deleted SiteAlerts
                 `, 'info');
 

--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -98,31 +98,18 @@ export default async function dbCleanup(req: NextApiRequest, res: NextApiRespons
         }
     }));
 
-    // item 5:
-    // Delete all notifications that are older than 30 days and have been processed 
-    promises.push(prisma.notification.deleteMany({
-        where: {
-            isDelivered: true,
-            sentAt: {
-                lt: new Date(new Date().getTime() - 90 * 24 * 60 * 60 * 1000)
-            }
-        }
-    }));
-
+    // We do not delete notifications, as we will need notifications data in the future for further analysis
 
     try {
 
-        const [deletedGeoEvent, deletedUsers, deletedSites, deletedSiteAlerts, deletedNotification] =
+        const [deletedGeoEvent, deletedUsers, deletedSites, deletedSiteAlerts] =
             await Promise.all(promises);
         
-        // Deleted ${deletedNotifications.count} notifications for soft-deleted SiteAlerts
-
         logger(`
                 Deleted ${deletedGeoEvent.count} geo events that are older than 30 days and have been processed
                 Deleted ${deletedUsers.count} users who've requested to be deleted and have deletedAt date older than 7 days
                 Deleted ${deletedSites.count} soft-deleted Sites
                 Deleted ${deletedSiteAlerts.count} soft-deleted SiteAlerts
-                Deleted ${deletedNotification.count} notifications that are older than 90 days and have been processed
                 `, 'info');
 
         res.status(200).json({

--- a/apps/server/src/server/api/routers/alertMethod.ts
+++ b/apps/server/src/server/api/routers/alertMethod.ts
@@ -134,6 +134,11 @@ export const alertMethodRouter = createTRPCRouter({
             });
             // If the existing alertMethod has been soft deleted, un-soft delete it, and return success
             if (existingAlertMethod?.deletedAt) {
+                // This block re-creates the soft-deleted alertMethod.
+                // Check if the user has reached the maximum limit of alert methods for all alertMethods (e.g., 5)
+                // If limit has reached, the function will throw an error message
+                await limitAlertMethodBasedOnPlan({ctx, userId, userPlan: userPlan, method: input.method});
+                // Else, restore the soft-deleted alertMethod
                 const updatedAlertMethod = await ctx.prisma.alertMethod.update({
                     where: {
                         id: existingAlertMethod.id,

--- a/apps/server/src/utils/routers/alertMethod.ts
+++ b/apps/server/src/utils/routers/alertMethod.ts
@@ -26,7 +26,8 @@ export const limitSpecificAlertMethodPerUser = async ({
   const specificAlertMethodCount = await ctx.prisma.alertMethod.count({
     where: {
       userId,
-      method
+      method,
+      deletedAt: null
     },
   });
   if (specificAlertMethodCount >= count) {


### PR DESCRIPTION
This branch addresses improvements/fixes in the db-cleanup cron job. The updates include:

1. **SiteAlert Deletion Adjustment**: Now, old SiteAlerts are purged based on their eventDate rather than the deletedAt attribute.
2. **Notification Retention**: The process no longer removes Notifications as part of the database cleanup.
3. **AlertMethod Deletion**: AlertMethods that are soft-deleted for over 7 days are now permanently removed in the cleanup process. In the alertMethod router, for the db-cleanup, some adjustments were made:
 a. Soft-deleted AlertMethods can be reinstated within 7 days post-deletion, provided the creation threshold isn't exceeded. 
 b. The count for the creation cap now considers only active AlertMethods, excluding any that are soft-deleted.