### PR TITLE
Enhance Data Cleanup and Stats Tracking in db-cleanup cronjob

### DIFF
--- a/apps/server/prisma/migrations/20231219000000_stats/migration.sql
+++ b/apps/server/prisma/migrations/20231219000000_stats/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "Stats" (
+    "id" TEXT NOT NULL,
+    "metric" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+    "lastUpdated" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Stats_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Stats_metric_key" UNIQUE ("metric")
+);

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -151,6 +151,14 @@ model Notification {
     isDelivered Boolean   @default(false)
 }
 
+model Stats {
+    id           String   @id @default(cuid())
+    metric       String   @unique
+    count        Int
+    lastUpdated  DateTime 
+}
+
+
 enum Role {
     ROLE_CLIENT
     ROLE_ADMIN


### PR DESCRIPTION
This pull request introduces a significant overhaul to the db-cleanup script, particularly focusing on the introduction of a stats table and the accurate tracking of data deletions, including cascade deletions. 

### Changes:
**Introduction of Stats Table:** Implemented a new stats table in Prisma to track the count of deleted records. This table is updated with deletion counts during the cleanup process. 

**Accurate Cascade Deletion Counting:** Added logic to accurately track count of cascade deletions for siteAlerts, notifications sites and alertMethods related to each site and user. This ensures a comprehensive count of all deletions.

**Enhanced Stats Updating Mechanism:** Modified the mechanism for updating the stats table. The script now performs an upsert operation, ensuring that the deletion counts are accurately reflected in the stats table post-cleanup.