### PR TITLE
Decrease getAlerts to return only last 10 days

### DIFF
--- a/apps/server/src/server/api/routers/alert.ts
+++ b/apps/server/src/server/api/routers/alert.ts
@@ -13,7 +13,7 @@ export const alertRouter = createTRPCRouter({
         .query(async ({ ctx }) => {
             try {
                 const userId = ctx.user!.id;
-                const thirtyDaysAgo = subtractDays(new Date(), 30);
+                const tenDaysAgo = subtractDays(new Date(), 10);
                 const sitesWithAlerts = await ctx.prisma.site.findMany({
                     where: {
                         userId: userId,
@@ -21,7 +21,7 @@ export const alertRouter = createTRPCRouter({
                         alerts: {
                             some: {
                                 eventDate: {
-                                    gte: thirtyDaysAgo,
+                                    gte: tenDaysAgo,
                                 },
                                 deletedAt: null,
                             },
@@ -54,7 +54,7 @@ export const alertRouter = createTRPCRouter({
                             },
                             where: {
                                 eventDate: {
-                                    gte: thirtyDaysAgo,
+                                    gte: tenDaysAgo,
                                 },
                                 deletedAt: null,
                             }


### PR DESCRIPTION
Getting alerts for last 30 days give a data load to the client. As a temporary fix, we are decreasing the data load by returning only last 10 days of alerts.
