### PR TITLE
fixed refresh token issue

### DIFF
--- a/apps/nativeapp/app/routes/AppNavigator.tsx
+++ b/apps/nativeapp/app/routes/AppNavigator.tsx
@@ -14,7 +14,7 @@ import {
   updateAccessToken,
 } from '../redux/slices/login/loginSlice';
 import {CommonStack, SignInStack} from './stack';
-import {clearAll, getData} from '../utils/localStorage';
+import {clearAll, getData, storeData} from '../utils/localStorage';
 import {useAppDispatch, useAppSelector, useOneSignal} from '../hooks';
 import useAppLinkHandler from '../hooks/notification/useAppLinkHandler';
 
@@ -81,6 +81,7 @@ export default function AppNavigator() {
                   onSuccess: () => {},
                   onFail: () => {},
                 };
+                storeData('cred', newAccessToken);
                 dispatch(updateAccessToken(newAccessToken?.accessToken));
                 dispatch(getUserDetails(request));
                 dispatch(updateIsLoggedIn(true));


### PR DESCRIPTION
Fixes #

Changes in this pull request:
-
- new refresh token will be stored in local storage now [ issue was occurring because of using already used refresh token for getting new token ].
