### PR TITLE
Generate siteAlert for MultiPolygon sites

### DIFF
--- a/apps/server/src/Services/SiteAlert/CreateSiteAlert.ts
+++ b/apps/server/src/Services/SiteAlert/CreateSiteAlert.ts
@@ -10,42 +10,76 @@ const createSiteAlerts = async (
 ) => {
   let siteAlertsCreatedCount = 0;
   try {
-    const siteAlertCreationQuery = Prisma.sql`
-            INSERT INTO "SiteAlert" (id, TYPE, "isProcessed", "eventDate", "detectedBy", confidence, latitude, longitude, "siteId", "data", "distance")
-            SELECT
-                gen_random_uuid (),
-                e.type,
-                FALSE,
-                e. "eventDate",
-                ${geoEventProviderClientId},
-                e.confidence,
-                e.latitude,
-                e.longitude,
-                s.id,
-                e.data,
-                ST_Distance(ST_SetSRID (e.geometry, 4326), s. "detectionGeometry") AS distance
-            FROM
-                "GeoEvent" e
-                INNER JOIN "Site" s ON ST_Within(ST_SetSRID (e.geometry, 4326), s. "detectionGeometry")
-                    AND s. "deletedAt" IS NULL
-                    AND s. "isMonitored" = TRUE
-                    AND (
-                      s."stopAlertUntil" IS NULL OR 
-                      s."stopAlertUntil" < CURRENT_TIMESTAMP
-                    )
-            WHERE
-                e. "isProcessed" = FALSE
-                AND e. "geoEventProviderId" = ${geoEventProviderId}
-                AND s.slices @> ('["' || ${slice} || '"]')::jsonb
-                AND NOT EXISTS (
-                    SELECT
-                        1
-                    FROM
-                        "SiteAlert"
-                    WHERE
-                        "SiteAlert".longitude = e.longitude
-                        AND "SiteAlert".latitude = e.latitude
-                        AND "SiteAlert"."eventDate" = e. "eventDate")`;
+    const siteAlertCreationQuery = Prisma.sql`INSERT INTO "SiteAlert" (id, TYPE, "isProcessed", "eventDate", "detectedBy", confidence, latitude, longitude, "siteId", "data", "distance")
+
+    SELECT
+        gen_random_uuid(),
+        e.type,
+        FALSE,
+        e."eventDate",
+        ${geoEventProviderClientId},
+        e.confidence,
+        e.latitude,
+        e.longitude,
+        s.id AS SiteId,
+        e.data,
+        ST_Distance(ST_SetSRID(ST_MakePoint(e.longitude, e.latitude), 4326), ST_GeomFromEWKB(decode(dg_elem, 'hex'))) AS distance
+    FROM
+        "GeoEvent" e
+    CROSS JOIN 
+        "Site" s,
+        jsonb_array_elements_text(s."geometry"->'detection_geometry') AS dg_elem
+    WHERE
+        s."type" = 'MultiPolygon'
+        AND s."deletedAt" IS NULL
+        AND s."isMonitored" = TRUE
+        AND (s."stopAlertUntil" IS NULL OR s."stopAlertUntil" < CURRENT_TIMESTAMP)
+        AND e."isProcessed" = FALSE
+        AND e. "geoEventProviderId" = ${geoEventProviderId}
+        AND s.slices @> ('["' || ${slice} || '"]')::jsonb
+        AND ST_Within(ST_SetSRID(ST_MakePoint(e.longitude, e.latitude), 4326), ST_GeomFromEWKB(decode(dg_elem, 'hex')))
+        AND NOT EXISTS (
+            SELECT 1
+            FROM "SiteAlert"
+            WHERE "SiteAlert".longitude = e.longitude
+                AND "SiteAlert".latitude = e.latitude
+                AND "SiteAlert"."eventDate" = e."eventDate"
+                AND "SiteAlert"."siteId" = s.id
+        )
+    
+    UNION
+    
+    SELECT
+        gen_random_uuid(),
+        e.type,
+        FALSE,
+        e."eventDate",
+        ${geoEventProviderClientId},
+        e.confidence,
+        e.latitude,
+        e.longitude,
+        s.id AS SiteId,
+        e.data,
+        ST_Distance(ST_SetSRID(e.geometry, 4326), s."detectionGeometry") AS distance
+    FROM
+        "GeoEvent" e
+    INNER JOIN "Site" s ON ST_Within(ST_SetSRID(e.geometry, 4326), s."detectionGeometry")
+        AND s."deletedAt" IS NULL
+        AND s."isMonitored" = TRUE
+        AND (s."stopAlertUntil" IS NULL OR s."stopAlertUntil" < CURRENT_TIMESTAMP)
+        AND e."isProcessed" = FALSE
+        AND e. "geoEventProviderId" = ${geoEventProviderId}
+        AND s.slices @> ('["' || ${slice} || '"]')::jsonb
+        AND (s.type = 'Polygon' OR s.type = 'Point')
+        AND NOT EXISTS (
+            SELECT 1
+            FROM "SiteAlert"
+            WHERE "SiteAlert".longitude = e.longitude
+                AND "SiteAlert".latitude = e.latitude
+                AND "SiteAlert"."eventDate" = e."eventDate"
+                AND "SiteAlert"."siteId" = s.id
+        );
+    `;
 
     const updateGeoEventIsProcessedToTrue = Prisma.sql`UPDATE "GeoEvent" SET "isProcessed" = true WHERE "isProcessed" = false AND "geoEventProviderId" = ${geoEventProviderId} AND "slice" = ${slice}`;
 

--- a/apps/server/src/Services/SiteAlert/CreateSiteAlert.ts
+++ b/apps/server/src/Services/SiteAlert/CreateSiteAlert.ts
@@ -28,7 +28,7 @@ const createSiteAlerts = async (
         "GeoEvent" e
     CROSS JOIN 
         "Site" s,
-        jsonb_array_elements_text(s."geometry"->'detection_geometry') AS dg_elem
+        jsonb_array_elements_text(s."geometry"->'properties'->'detection_geometry') AS dg_elem
     WHERE
         s."type" = 'MultiPolygon'
         AND s."deletedAt" IS NULL

--- a/apps/server/src/pages/api/cron/geo-event-fetcher.ts
+++ b/apps/server/src/pages/api/cron/geo-event-fetcher.ts
@@ -6,7 +6,6 @@ import { type GeoEventProvider } from '@prisma/client'
 import { type GeoEventProviderConfig } from '../../../Interfaces/GeoEventProvider'
 import { env } from "../../../env.mjs";
 import processGeoEvents from "../../../../src/Services/GeoEvent/GeoEventHandler";
-import createNotifications from "../../../../src/Services/Notifications/CreateNotifications";
 import createSiteAlerts from "../../../../src/Services/SiteAlert/CreateSiteAlert";
 import { logger } from "../../../../src/server/logger";
 import { type GeoEventProviderClientId } from "../../../Interfaces/GeoEventProvider";

--- a/apps/server/src/server/api/zodSchemas/site.schema.ts
+++ b/apps/server/src/server/api/zodSchemas/site.schema.ts
@@ -12,9 +12,23 @@ const PolygonSchema = z.object({
 });
 
 
+// const MultiPolygonSchema = z.object({
+//     type: z.literal("MultiPolygon"),
+//     coordinates: z.array(z.array(z.union([z.tuple([z.number(), z.number()]), z.tuple([z.number(), z.number(), z.optional(z.number())])])))
+// });
+
 const MultiPolygonSchema = z.object({
     type: z.literal("MultiPolygon"),
-    coordinates: z.array(z.array(z.union([z.tuple([z.number(), z.number()]), z.tuple([z.number(), z.number(), z.optional(z.number())])])))
+    coordinates: z.array(
+        z.array(
+            z.array(
+                z.union([
+                    z.tuple([z.number(), z.number()]),
+                    z.tuple([z.number(), z.number(), z.optional(z.number())])
+                ])
+            )
+        )
+    )
 });
 
 export const createSiteSchema = z.object({

--- a/docs/create-postgis-triggers.sql
+++ b/docs/create-postgis-triggers.sql
@@ -36,7 +36,7 @@ BEGIN
             ));
         END LOOP;
 
-        NEW."geometry" = jsonb_set(NEW."geometry", '{detection_geometry}', to_jsonb(detectionGeometryHex));
+        NEW."geometry" = jsonb_set(NEW."geometry", '{properties}', jsonb_build_object('detection_geometry', to_jsonb(detectionGeometryHex)));
 
         -- Calculate detectionGeometry for MultiPolygon as a whole
         NEW."detectionGeometry" = ST_Collect(ARRAY(

--- a/docs/create-postgis-triggers.sql
+++ b/docs/create-postgis-triggers.sql
@@ -1,12 +1,53 @@
+-- Enable PostGIS extension
+CREATE EXTENSION IF NOT EXISTS postgis;
+
 -- Add trigger to Site to generate detection geometry and determine slices
 CREATE OR REPLACE FUNCTION app_site_detectionGeometry_update() 
 RETURNS TRIGGER AS $$
 DECLARE
     sliceKeys TEXT[];
+    detectionGeometryHex TEXT[];
+    polygon JSONB;
 BEGIN
-    -- Generate detection geometry
-    NEW."originalGeometry" = ST_Transform(ST_Transform(ST_GeomFromGeoJSON(NEW."geometry"::text), 3857), 4326);
-    NEW."detectionGeometry" = ST_Transform(ST_Buffer(ST_Transform(ST_GeomFromGeoJSON(NEW."geometry"::text), 3857), NEW."radius"), 4326);
+    IF NEW."type" = 'MultiPolygon' THEN
+        detectionGeometryHex := ARRAY[]::TEXT[];
+
+        FOR polygon IN SELECT jsonb_array_elements(NEW."geometry"->'coordinates')
+        LOOP
+            detectionGeometryHex := array_append(detectionGeometryHex, encode(
+                ST_AsEWKB(
+                    ST_Transform(
+                        ST_Buffer(
+                            ST_Transform(
+                                ST_GeomFromGeoJSON(
+                                    jsonb_build_object(
+                                        'type', 'Polygon',
+                                        'coordinates', polygon
+                                    )::text
+                                ),
+                                3857
+                            ),
+                            NEW."radius"
+                        ),
+                        4326
+                    )
+                ),
+                'hex'
+            ));
+        END LOOP;
+
+        NEW."geometry" = jsonb_set(NEW."geometry", '{detection_geometry}', to_jsonb(detectionGeometryHex));
+
+        -- Calculate detectionGeometry for MultiPolygon as a whole
+        NEW."detectionGeometry" = ST_Collect(ARRAY(
+        SELECT ST_GeomFromEWKB(decode(dg_elem, 'hex'))
+        FROM jsonb_array_elements_text(NEW."geometry"->'detection_geometry') AS dg_elem
+        ));
+    ELSE
+        -- Handle Point and Polygon as before
+        NEW."originalGeometry" = ST_Transform(ST_Transform(ST_GeomFromGeoJSON(NEW."geometry"::text), 3857), 4326);
+        NEW."detectionGeometry" = ST_Transform(ST_Buffer(ST_Transform(ST_GeomFromGeoJSON(NEW."geometry"::text), 3857), NEW."radius"), 4326);
+    END IF;
 
     -- Calculate detection area
     NEW."detectionArea" := ST_Area(
@@ -64,9 +105,6 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER site_update_trigger
 BEFORE INSERT OR UPDATE OF "geometry", "radius", "slices" ON "Site"
 FOR EACH ROW EXECUTE FUNCTION app_site_detectionGeometry_update();
-
--- Enable PostGIS extension
-CREATE EXTENSION IF NOT EXISTS postgis;
 
 -- Add trigger to GeoEvent table
 CREATE OR REPLACE FUNCTION handle_geoevent() 


### PR DESCRIPTION
This pull request addresses a critical functionality gap in FireAlert regarding the detection of siteAlerts for MultiPolygon sites. Previously, our system encountered limitations with POSTGIS functions such as ST_Within and ST_Intersects, which were not effectively processing MultiPolygon geometries. To overcome this challenge, we have innovatively introduced a detection_geometry key within the geometry attribute of all MultiPolygon sites. This key is an array consisting of hex-encoded POSTGIS geometries for each polygon within the MultiPolygon structure.

Significant modifications were made to the site insert/update SQL trigger function to accommodate and reflect this enhancement. This change ensures that the trigger function correctly processes and stores the necessary geometry data for MultiPolygon sites.

For the creation of siteAlerts, we maintained the existing logic for Polygon and Point Sites. However, for MultiPolygon Sites, we implemented a more robust approach. The process now involves iterating through each element within the detection_geometry array to identify any potential matches. A siteAlert is generated only if a match is found within these geometries.

This update marks a substantial improvement in our system's capability to accurately detect and respond to relevant siteAlerts for MultiPolygon sites