### PR TITLE
Enhance User Deletion Process and Fix emailVerified Issue in User Table

### DIFF
--- a/apps/server/src/utils/routers/user.ts
+++ b/apps/server/src/utils/routers/user.ts
@@ -105,8 +105,9 @@ export async function handleNewUser(bearer_token: string) {
   // Auth0 has a bug where email_verified is a sometimes string instead of a boolean
   // Therefore check both string and boolean values
 
-  const email_verified =
-    userData.email_verified === 'true' ? true : false;
+  const email_verified = (typeof userData.email_verified === 'boolean' && userData.email_verified === true) || 
+                        (typeof userData.email_verified === 'string' && 
+                        userData.email_verified.toLowerCase() === 'true');
 
   const getPlanetUser = await planetUser(bearer_token);
   const isPlanetRO = getPlanetUser.isPlanetRO;

--- a/apps/server/src/utils/routers/user.ts
+++ b/apps/server/src/utils/routers/user.ts
@@ -105,7 +105,7 @@ export async function handleNewUser(bearer_token: string) {
   // Auth0 has a bug where email_verified is a sometimes string instead of a boolean
   // Therefore check both string and boolean values
 
-  const email_verified = (typeof userData.email_verified === 'boolean' && userData.email_verified === true) || 
+  const email_verified = (typeof userData.email_verified === 'boolean' && userData.email_verified) || 
                         (typeof userData.email_verified === 'string' && 
                         userData.email_verified.toLowerCase() === 'true');
 


### PR DESCRIPTION
This PR introduces soft-deletion for 'sites' and 'alertMethods' during user deletion to optimize database cleanup and reinstatement logic. Additionally, it addresses a bug where 'emailVerified' in the 'User' table is incorrectly marked due to a type mismatch with AuthO responses, by updating existing records to ensure accurate verification status.

Considering that previous records incorrectly had emailVerified as false and the corresponding AlertMethod as unverified, executing the following SQL scripts will rectify these discrepancies in the database:
```
UPDATE "AlertMethod"
SET "isVerified" = true
WHERE "destination" IN (
    SELECT u."email"
    FROM "User" u
    JOIN "AlertMethod" am ON u."email" = am."destination"
    WHERE u."emailVerified" = false
      AND am."isVerified" = false
      AND am."method" = 'email'
);

UPDATE "User"
SET "emailVerified" = true
WHERE "emailVerified" = false;
```