### PR TITLE
Implement Backend Validation for Site Area Limit

### DIFF
--- a/apps/server/src/server/api/routers/site.ts
+++ b/apps/server/src/server/api/routers/site.ts
@@ -14,32 +14,6 @@ export const siteRouter = createTRPCRouter({
         .input(createSiteSchema)
         .mutation(async ({ctx, input}) => {
             const userId = ctx.user!.id;
-            // const userPlan = ctx.user!.plan ? ctx.user!.plan as UserPlan : 'basic';
-            // const siteCount = await ctx.prisma.site.count({
-            //     where:{
-            //         userId,
-            //     }
-            // })
-            // if(userPlan === 'basic'){
-            //     if (siteCount >= 20){
-            //         return {
-            //             status: 'error',
-            //             httpStatus: 403,
-            //             code: 'FORBIDDEN',
-            //             message: `You've exceeded the fair site use limits of FireAlert. Please contact info@plant-for-the-planet to remove these limits for your account.`,
-            //         };
-            //     }
-            // }
-            // if(userPlan === 'custom'){
-            //     if (siteCount >= 50){
-            //         return {
-            //             status: 'error',
-            //             httpStatus: 403,
-            //             code: 'FORBIDDEN',
-            //             message: `You've exceeded the fair site use limits of FireAlert. You cannot create any more sites.`,
-            //         };
-            //     }
-            // }
             try {
                 const origin = 'firealert';
                 const lastUpdated = new Date();
@@ -54,6 +28,35 @@ export const siteRouter = createTRPCRouter({
                     radius = input.radius;
                 }
 
+                // Convert geometry to GeoJSON string for PostGIS function
+                const geometryGeoJSON = JSON.stringify(input.geometry);
+
+                // Calculate detection area using PostGIS
+                const result = await ctx.prisma.$queryRaw`SELECT ST_Area(
+                    ST_Transform(
+                        ST_Buffer(
+                        ST_Transform(
+                            ST_SetSRID(
+                            ST_GeomFromGeoJSON(${geometryGeoJSON}::text),
+                            4326
+                            ),
+                            3857
+                        ),
+                        ${input.radius}
+                        ),
+                        3857
+                    )
+                    ) AS area`;
+
+                const detectionArea = result[0].area; // Assuming result is an array with the area as its first item
+
+                // Check if the detection area exceeds 1 million hectares (10,000 square kilometers)
+                if (detectionArea > 1e8) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'Site area exceeds the maximum allowed size of 1 million hectares.',
+                });
+                }
                 const site = await ctx.prisma.site.create({
                     data: {
                         origin: origin,

--- a/apps/server/src/server/api/routers/site.ts
+++ b/apps/server/src/server/api/routers/site.ts
@@ -51,7 +51,7 @@ export const siteRouter = createTRPCRouter({
                 const detectionArea = result[0].area; // Assuming result is an array with the area as its first item
 
                 // Check if the detection area exceeds 1 million hectares (10,000 square kilometers)
-                if (detectionArea > 1e8) {
+                if (detectionArea > 1e10) {
                 throw new TRPCError({
                     code: 'BAD_REQUEST',
                     message: 'Site area exceeds the maximum allowed size of 1 million hectares.',

--- a/apps/server/src/server/api/zodSchemas/site.schema.ts
+++ b/apps/server/src/server/api/zodSchemas/site.schema.ts
@@ -11,12 +11,6 @@ const PolygonSchema = z.object({
     coordinates: z.array(z.array(z.union([z.tuple([z.number(), z.number()]), z.tuple([z.number(), z.number(), z.optional(z.number())])])))
 });
 
-
-// const MultiPolygonSchema = z.object({
-//     type: z.literal("MultiPolygon"),
-//     coordinates: z.array(z.array(z.union([z.tuple([z.number(), z.number()]), z.tuple([z.number(), z.number(), z.optional(z.number())])])))
-// });
-
 const MultiPolygonSchema = z.object({
     type: z.literal("MultiPolygon"),
     coordinates: z.array(


### PR DESCRIPTION
Implemented a backend validation to enforce a maximum site area of 1 million hectares, aligning with the existing frontend check. This addition ensures consistency between frontend and backend validations, preventing the creation or update of sites exceeding the area limit directly through API calls. The update includes calculating the site area using PostGIS during site creation or update and returning an error if the limit is surpassed.