### PR TITLE
Remove newGeoEvent check before siteAlert creation

### DIFF
--- a/apps/server/src/pages/api/cron/geo-event-fetcher.ts
+++ b/apps/server/src/pages/api/cron/geo-event-fetcher.ts
@@ -124,12 +124,12 @@ export default async function alertFetcher(req: NextApiRequest, res: NextApiResp
           logger(`${breadcrumbPrefix} Found ${totalNewGeoEvent} new Geo Events`, "info");
           logger(`${breadcrumbPrefix} Created ${totalEventCount} Geo Events`, "info");
 
-          if (totalNewGeoEvent > 0) {
+          // if (totalNewGeoEvent > 0) {
           const alertCount = await createSiteAlerts(geoEventProviderId, geoEventProviderClientId as GeoEventProviderClientId, slice)
           logger(`${breadcrumbPrefix} Created ${alertCount} Site Alerts.`, "info");
 
           newSiteAlertCount += alertCount
-          }
+          // }
 
           // Update lastRun value of the provider to the current Date()
           await prisma.geoEventProvider.update({


### PR DESCRIPTION
Creating siteAlerts only when new geoEvents are created might result into issues where some geoEvents never gets processed. This PR removes the if check.