### PR TITLE
Fix sendVerificationCode return

### DIFF
--- a/apps/server/src/utils/routers/alertMethod.ts
+++ b/apps/server/src/utils/routers/alertMethod.ts
@@ -338,7 +338,7 @@ export const handlePendingVerification = async (
       authenticationMessage: true,
       otp: otp
     }
-    await notifier.notify(alertMethod.destination, params);
+    sendVerificationCode = await notifier.notify(alertMethod.destination, params);
   } else {
     // Use NotifierRegistry to send the verification code
     const notifier = NotifierRegistry.get(alertMethod.method);


### PR DESCRIPTION
There was an error when displaying success message. When WhatsApp was sent successfully, an failure message was instead displayed. This hotfix corrects the return message.