### PR TITLE
Update stats.lastUpdated on upsert

### DIFF
--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -30,7 +30,7 @@ function shouldContinueDeletion(startTime: number, type_of_cleanup:string = 'dat
 async function updateOrCreateStats(metric: string, count: number) {
     await prisma.stats.upsert({
         where: {metric: metric},
-        update: {count: {increment: count}},
+        update: {count: {increment: count}, lastUpdated: new Date()},
         create: {
             metric: metric,
             count: count,


### PR DESCRIPTION
Stats tables are updated using prisma upsert. FireAlert's current implementation correctly writes to lastUpdated during create, but fails to do so during update. This PR fixes this issue. 