### PR TITLE
Avoid device duplication in createAlertMethod

### DIFF
--- a/apps/server/src/server/api/routers/alertMethod.ts
+++ b/apps/server/src/server/api/routers/alertMethod.ts
@@ -175,9 +175,16 @@ export const alertMethodRouter = createTRPCRouter({
                 if (isDeviceVerified) {
 
                     // Check if the destination (PlayerID) already exists in the table
+                    // Retrieve alert methods that match the destination or (userId and deviceName)
                     const existingAlertMethods = await ctx.prisma.alertMethod.findMany({
                         where: {
-                            destination: input.destination
+                            OR: [
+                                {destination: input.destination},
+                                {AND: [
+                                    {userId: userId},
+                                    {deviceName: input.deviceName}
+                                ]}
+                            ]
                         }
                     });
 


### PR DESCRIPTION
When user installs FireAlert app from the same phone after deleting the app, createAlertMethod does not detect that it is the same device, so creates the alertMethod again. The deviceName, however, usually remains unchanged. This commit leverages the constancy of deviceName to prevent duplicate device alertMethods.