### PR TITLE
Add view_site and view_siteAlert Views for Filtered Data Access

### DIFF
--- a/apps/server/prisma/migrations/20240404000000_create_view/migration.sql
+++ b/apps/server/prisma/migrations/20240404000000_create_view/migration.sql
@@ -1,0 +1,30 @@
+-- Site View
+CREATE OR REPLACE VIEW view_site AS
+SELECT
+    "id",
+    "name",
+    "type",
+    "radius",
+    "isMonitored",
+    "userId",
+    "slices"
+FROM
+    "Site"
+WHERE
+    "deletedAt" IS NULL;
+
+-- SiteAlert View
+CREATE OR REPLACE VIEW view_siteAlert AS
+SELECT
+    "id",
+    "siteId",
+    "type",
+    "latitude",
+    "longitude",
+    "eventDate",
+    "detectedBy",
+    "confidence"
+FROM
+    "SiteAlert"
+WHERE
+    "deletedAt" IS NULL;


### PR DESCRIPTION
This PR introduces two new views, view_site and view_siteAlert, to provide simplified access to active sites and site alerts, respectively, by filtering out records marked as deleted.