### PR TITLE
Kenya Block listed

### DIFF
--- a/apps/server/src/utils/notification/restrictedSMS.ts
+++ b/apps/server/src/utils/notification/restrictedSMS.ts
@@ -15,6 +15,7 @@ const restrictedCountryCodesSms = [
     'UZ', // Uzbekistan
     'AF', // Afghanistan
     'BZ', // Belize
+    'KE', //Kenya
 ];
 
 const restrictedCountryCodesWhatsapp = [


### PR DESCRIPTION
Fixes #

Changes in this pull request:
Kenya has been added to the blocklist due to error code 21612, which indicates the following:
  1. The carrier in Kenya does not have a direct route or agreement to receive messages from your Twilio sender ID/number.
  2. The route between your sender ID and the recipient's carrier is blocked or unavailable.
  
I plan to add code later to handle this issue. I will review the documentation to gain a better understanding of all potential cases.