### PR TITLE
Corrected Caching duration

### DIFF
--- a/apps/server/src/pages/api/v1/fires/index.ts
+++ b/apps/server/src/pages/api/v1/fires/index.ts
@@ -81,10 +81,10 @@ export default async function firesBySiteHandler(
     if(CACHING) {
       res.setHeader(
         "Cache-Control",
-        "public, max-age=7200 s-maxage=3600, stale-while-revalidate=7200"
+        "public, max-age=1800, s-maxage=86400, stale-while-revalidate=86400"
       );
-      res.setHeader("CDN-Cache-Control", "max-age=7200");
-      res.setHeader("Cloudflare-CDN-Cache-Control", "max-age=7200");
+      res.setHeader("CDN-Cache-Control", "max-age=86400");
+      res.setHeader("Cloudflare-CDN-Cache-Control", "max-age=86400");
     }
 
     res.status(200).json(fires);


### PR DESCRIPTION
Fixes the API caching duration.

1800 seconds → 30 minutes
86400 seconds → 1 day

![Screenshot 2025-02-12 at 21 35 03](https://github.com/user-attachments/assets/0079e167-494a-4d5b-82d6-feac3b0f2095)

I also have been noticing even though this updated caching duration works Preview Environment,
With Same env variable values caching duration does not work on the Production Environment

@shyambhongle @sagararyal 
