### PR TITLE
updated Config (1769 MB / 1 vCPU)

### DIFF
--- a/apps/server/src/pages/api/cron/geo-event-fetcher.ts
+++ b/apps/server/src/pages/api/cron/geo-event-fetcher.ts
@@ -16,6 +16,7 @@ import { type geoEventInterface as GeoEvent } from "../../../Interfaces/GeoEvent
 // 300s is the maximum allowed duration for Vercel pro plans
 export const config = {
   maxDuration: 300,
+  memory: 1769,
 };
 
 // TODO: Run this cron every 5 minutes


### PR DESCRIPTION

Changes in this pull request:
Increased memory configuration for `geo-event-fetcher` to get benefit of Standard Compute (1769 MB / 1 vCPU).

@shyambhongle @sagararyal 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to allocate additional memory resources for the geo-event fetcher process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->