### PR TITLE
change cron behavior for geo event fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .DS_Store
 .turbo
 .idea
+.vercel

--- a/apps/server/src/pages/api/cron/geo-event-fetcher.ts
+++ b/apps/server/src/pages/api/cron/geo-event-fetcher.ts
@@ -30,7 +30,7 @@ export default async function alertFetcher(req: NextApiRequest, res: NextApiResp
     }
   }
 
-  // Set Limit to 7 if not provided or greater than 10
+  // Set Limit to 7 if not provided or greater than 7
   // Extract limit from query
   const rawLimit = req.query['limit'];
 
@@ -39,13 +39,13 @@ export default async function alertFetcher(req: NextApiRequest, res: NextApiResp
 
   if (typeof rawLimit === 'string') {
     const parsedLimit = parseInt(rawLimit, 10);
-    if (isNaN(parsedLimit) || parsedLimit > 15) {
-      limit = 15;
+    if (isNaN(parsedLimit) || parsedLimit > 7) {
+      limit = 7;
     } else {
       limit = parsedLimit;
     }
   } else {
-    limit = 4;
+    limit = 2;
   }
 
 
@@ -55,7 +55,7 @@ export default async function alertFetcher(req: NextApiRequest, res: NextApiResp
 
   let newSiteAlertCount = 0;
   let processedProviders = 0;
-  const fetchCount = Math.max(5, limit * 2);
+  const fetchCount = limit;
   // while (processedProviders <= limit) {
     const activeProviders: GeoEventProvider[] = await prisma.$queryRaw`
         SELECT *


### PR DESCRIPTION
Sets default providers to process to 2
fixes limit to use value from cron query, and 
sets max providers on a request to 7