### PR TITLE
Hotfix/cleanup notifications

### DIFF
--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -392,8 +392,7 @@ async function cleanNotifications(startTime: number) {
     // Delete Notifications which have sentAt Older than 90 Days (if NULL Do not delete)
     const notificationsToDelete = await prisma.notification.findMany({
       where: {
-        sentAt: {
-          not: null,
+        createdAt: {
           lt: new Date(
             currentDateTimeAt1AM.getTime() - 90 * 24 * 60 * 60 * 1000,
           ),


### PR DESCRIPTION
Changes in this pull request:

**Important**
First To update the Existing createdAt to sync with sentAt for the past ones 
```
UPDATE "Notification"
SET "createdAt" = "sentAt"
WHERE "sentAt" IS NOT NULL
  AND "sentAt" < NOW();
```
After the sync it is suggested to Apply this PR's changes.

Here It changes the Logic to Check with `Notification.createdAt`.
Notifications that are created 90 days older but not sent (sentAt is null or not sent for any reason) is of no Use.

@sagararyal 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Notifications now record creation timestamps automatically.
  * Scheduled cleanup includes removing notifications older than 90 days with clearer per-type deletion stats.
* Refactor
  * Modularized cleanup logic and added a watchdog to prevent long-running jobs from timing out.
  * Enhanced error handling for more reliable cleanup runs.
* Chores
  * Updated runtime requirement to Node.js 22.
  * Adjusted dependencies, including removing profiling and updating tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->