### PR TITLE
feat(incident): enforce STOP_ALERTS notification suppression 

### DIFF
--- a/apps/nativeapp/app/types/incident.ts
+++ b/apps/nativeapp/app/types/incident.ts
@@ -54,7 +54,7 @@ export interface IncidentData {
   isProcessed: boolean;
   startNotificationId: string | null;
   endNotificationId: string | null;
-  reviewStatus: 'to_review' | 'in_review' | 'reviewed';
+  reviewStatus: 'TO_REVIEW' | 'STOP_ALERTS';
   createdAt: Date;
   updatedAt: Date;
 

--- a/apps/server/prisma/migrations/20260314171528_siteincident_reviewstaus_update_string_to_enum/migration.sql
+++ b/apps/server/prisma/migrations/20260314171528_siteincident_reviewstaus_update_string_to_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `reviewStatus` column on the `SiteIncident` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "SiteIncidentReviewStatus" AS ENUM ('TO_REVIEW', 'STOP_ALERTS');
+
+-- AlterTable
+ALTER TABLE "SiteIncident" DROP COLUMN "reviewStatus",
+ADD COLUMN     "reviewStatus" "SiteIncidentReviewStatus" NOT NULL DEFAULT 'TO_REVIEW';

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -157,25 +157,25 @@ model SiteAlert {
 }
 
 model SiteIncident {
-    id                  String      @id @default(cuid())
+    id                  String                   @id @default(cuid())
     siteId              String
     startSiteAlertId    String
     endSiteAlertId      String?
     latestSiteAlertId   String
-    startedAt           DateTime    @default(now())
+    startedAt           DateTime                 @default(now())
     endedAt             DateTime?
-    isActive            Boolean     @default(true)
-    isProcessed         Boolean     @default(false)
+    isActive            Boolean                  @default(true)
+    isProcessed         Boolean                  @default(false)
     startNotificationId String?
     endNotificationId   String?
-    reviewStatus        String      @default("to_review")
-    createdAt           DateTime    @default(now())
-    updatedAt           DateTime    @updatedAt
-    site                Site        @relation(fields: [siteId], references: [id], onDelete: Cascade)
-    startSiteAlert      SiteAlert   @relation("startAlert", fields: [startSiteAlertId], references: [id])
-    latestSiteAlert     SiteAlert   @relation("latestAlert", fields: [latestSiteAlertId], references: [id])
-    endSiteAlert        SiteAlert?  @relation("endAlert", fields: [endSiteAlertId], references: [id])
-    siteAlerts          SiteAlert[] @relation("incidentAlerts")
+    reviewStatus        SiteIncidentReviewStatus @default(TO_REVIEW)
+    createdAt           DateTime                 @default(now())
+    updatedAt           DateTime                 @updatedAt
+    site                Site                     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+    startSiteAlert      SiteAlert                @relation("startAlert", fields: [startSiteAlertId], references: [id])
+    latestSiteAlert     SiteAlert                @relation("latestAlert", fields: [latestSiteAlertId], references: [id])
+    endSiteAlert        SiteAlert?               @relation("endAlert", fields: [endSiteAlertId], references: [id])
+    siteAlerts          SiteAlert[]              @relation("incidentAlerts")
 
     metadata Json?
 
@@ -284,4 +284,9 @@ enum NotificationStatus {
     START_SENT
     END_SCHEDULED
     END_SENT
+}
+
+enum SiteIncidentReviewStatus {
+    TO_REVIEW
+    STOP_ALERTS
 }

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -83,7 +83,7 @@ model Site {
     lastMessageCreated DateTime?
     detectionArea      Float?                   @default(0)
     alerts             SiteAlert[]
-    incidents          SiteIncident[]
+    siteIncidents      SiteIncident[]
     project            Project?                 @relation(fields: [projectId], references: [id])
     user               User?                    @relation(fields: [userId], references: [id], onDelete: Cascade)
     siteRelations      SiteRelation[]

--- a/apps/server/src/Interfaces/SiteIncident.ts
+++ b/apps/server/src/Interfaces/SiteIncident.ts
@@ -3,7 +3,12 @@
  * Defines all data structures for the SiteIncident system
  */
 
-import {type SiteAlert, type Site, type Notification} from '@prisma/client';
+import {
+  type SiteAlert,
+  type Site,
+  type Notification,
+  SiteIncidentReviewStatus,
+} from '@prisma/client';
 
 /**
  * Core SiteIncident interface representing a grouped fire event
@@ -20,7 +25,7 @@ export interface SiteIncidentInterface {
   isProcessed: boolean;
   startNotificationId?: string | null;
   endNotificationId?: string | null;
-  reviewStatus: string;
+  reviewStatus: SiteIncidentReviewStatus;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -46,7 +51,7 @@ export interface UpdateIncidentData {
   isProcessed?: boolean;
   startNotificationId?: string | null;
   endNotificationId?: string | null;
-  reviewStatus?: string;
+  reviewStatus?: SiteIncidentReviewStatus;
 }
 
 /**
@@ -150,8 +155,6 @@ export enum NotificationStatus {
  * Incident review status
  */
 export enum ReviewStatus {
-  TO_REVIEW = 'to_review',
-  IN_REVIEW = 'in_review',
-  REVIEWED = 'reviewed',
-  ARCHIVED = 'archived',
+  TO_REVIEW = 'TO_REVIEW',
+  STOP_ALERTS = 'STOP_ALERTS',
 }

--- a/apps/server/src/Services/Notifications/CreateIncidentNotifications.ts
+++ b/apps/server/src/Services/Notifications/CreateIncidentNotifications.ts
@@ -4,7 +4,11 @@ import {
   type NotificationQueueItem,
   type IncidentNotificationMetadata,
 } from '../../Interfaces/SiteIncidentNotifications';
-import {NotificationStatus, type SiteIncident} from '@prisma/client';
+import {
+  NotificationStatus,
+  SiteIncidentReviewStatus,
+  type SiteIncident,
+} from '@prisma/client';
 import {isSiteIncidentMethod} from './NotificationRoutingConfig';
 
 export class CreateIncidentNotifications {
@@ -18,6 +22,11 @@ export class CreateIncidentNotifications {
     let totalNotificationsCreated = 0;
     let totalIncidentsProcessed = 0;
     let batchNumber = 0;
+    const skippedByMethod: Record<string, number> = {
+      email: 0,
+      sms: 0,
+      whatsapp: 0,
+    };
 
     // Process all unprocessed incidents in batches
     while (true) {
@@ -33,7 +42,10 @@ export class CreateIncidentNotifications {
       totalIncidentsProcessed += incidents.length;
 
       // 2. Create notification queue for this batch
-      const notificationQueue = await this.createNotificationQueue(incidents);
+      const notificationQueue = await this.createNotificationQueue(
+        incidents,
+        skippedByMethod,
+      );
 
       if (notificationQueue.length === 0) {
         // Mark incidents as processed even if no notifications were generated
@@ -52,6 +64,12 @@ export class CreateIncidentNotifications {
 
     logger(
       `CreateIncidentNotifications: Processed ${totalIncidentsProcessed} incidents in ${batchNumber} batches, Created ${totalNotificationsCreated} notifications (email, sms, whatsapp methods only)`,
+      'info',
+    );
+    const totalSkipped =
+      skippedByMethod.email + skippedByMethod.sms + skippedByMethod.whatsapp;
+    logger(
+      `CreateIncidentNotifications: Skipped ${totalSkipped} notifications due to STOP_ALERTS (email=${skippedByMethod.email}, sms=${skippedByMethod.sms}, whatsapp=${skippedByMethod.whatsapp})`,
       'info',
     );
 
@@ -99,6 +117,7 @@ export class CreateIncidentNotifications {
 
   private async createNotificationQueue(
     incidents: any[],
+    skippedByMethod: Record<string, number>,
   ): Promise<NotificationQueueItem[]> {
     const queue: NotificationQueueItem[] = [];
     const methodCounters = new Map<string, Map<string, number>>();
@@ -129,6 +148,14 @@ export class CreateIncidentNotifications {
       );
 
       if (validMethods.length === 0) continue;
+
+      if (incident.reviewStatus === SiteIncidentReviewStatus.STOP_ALERTS) {
+        for (const method of validMethods) {
+          const methodKey = method.method;
+          skippedByMethod[methodKey] = (skippedByMethod[methodKey] || 0) + 1;
+        }
+        continue;
+      }
 
       // Determine Notification Type
       const isStart = incident.isActive;

--- a/apps/server/src/Services/Notifications/CreateNotifications.ts
+++ b/apps/server/src/Services/Notifications/CreateNotifications.ts
@@ -2,6 +2,7 @@ import {prisma} from '../../server/db';
 import {CustomError} from '../../utils/errorHandler';
 import {logger} from '../../server/logger';
 import {isSiteAlertMethod} from './NotificationRoutingConfig';
+import {SiteIncidentReviewStatus} from '@prisma/client';
 
 // Logic in Prisma:
 // Initialize an empty array → `notificationDataQueue` -> Queue for holding data required for conditional notification creation
@@ -86,6 +87,7 @@ type UnprocessedSiteAlert = {
   id: string;
   siteId: string;
   site: SiteAlertRelations;
+  siteIncident?: {reviewStatus: SiteIncidentReviewStatus} | null;
 };
 
 function createNestedChunksForUnprocessedSiteAlerts(
@@ -125,6 +127,7 @@ type ProcessSiteAlertChunkResult = {
 
 function processSiteAlertChunk(
   siteAlertChunk: UnprocessedSiteAlert[],
+  skippedByMethod: Record<string, number>,
 ): ProcessSiteAlertChunkResult {
   const notificationDataQueue: NotificationToBeProcessed[] = [];
   // [email, whatsapp, and sms] method have one count for each unique alertMethod,
@@ -166,6 +169,26 @@ function processSiteAlertChunk(
       });
       // Remove the siteId from the set
       uniqueSiteIdsForNewSiteAlerts.delete(siteId);
+    }
+
+    const stopAlerts =
+      siteAlert.siteIncident?.reviewStatus ===
+      SiteIncidentReviewStatus.STOP_ALERTS;
+    if (stopAlerts) {
+      if (alertMethods && alertMethods.length > 0) {
+        alertMethods.forEach(alertMethod => {
+          if (
+            alertMethod.isVerified &&
+            alertMethod.isEnabled &&
+            isSiteAlertMethod(alertMethod.method)
+          ) {
+            skippedByMethod[alertMethod.method] =
+              (skippedByMethod[alertMethod.method] || 0) + 1;
+          }
+        });
+      }
+      processedSiteAlerts.push(siteAlert.id);
+      continue;
     }
 
     if (alertMethods && alertMethods.length > 0) {
@@ -236,6 +259,10 @@ function processSiteAlertChunk(
 
 const createNotifications = async () => {
   let totalNotificationsCreated = 0;
+  const skippedByMethod: Record<string, number> = {
+    device: 0,
+    webhook: 0,
+  };
   try {
     logger(
       'Starting CreateNotifications for SiteAlert methods (device, webhook) only',
@@ -254,6 +281,11 @@ const createNotifications = async () => {
       select: {
         id: true,
         siteId: true,
+        siteIncident: {
+          select: {
+            reviewStatus: true,
+          },
+        },
         site: {
           select: {
             lastMessageCreated: true,
@@ -316,7 +348,7 @@ const createNotifications = async () => {
     );
     for (const siteAlertChunk of siteAlertsInChunks) {
       const {processedSiteAlerts, notificationCreateData, sitesToBeUpdated} =
-        processSiteAlertChunk(siteAlertChunk);
+        processSiteAlertChunk(siteAlertChunk, skippedByMethod);
       await prisma.$transaction(async prisma => {
         await prisma.siteAlert.updateMany({
           where: {id: {in: processedSiteAlerts}},
@@ -337,6 +369,11 @@ const createNotifications = async () => {
   }
   logger(
     `CreateNotifications completed. Created ${totalNotificationsCreated} SiteAlert notifications (device, webhook methods only)`,
+    'info',
+  );
+  const totalSkipped = skippedByMethod.device + skippedByMethod.webhook;
+  logger(
+    `CreateNotifications: Skipped ${totalSkipped} notifications due to STOP_ALERTS (device=${skippedByMethod.device}, webhook=${skippedByMethod.webhook})`,
     'info',
   );
   return totalNotificationsCreated;

--- a/apps/server/src/Services/Notifications/IncidentNotificaiton-StopAlerts.md
+++ b/apps/server/src/Services/Notifications/IncidentNotificaiton-StopAlerts.md
@@ -1,0 +1,91 @@
+## Tasks
+
+Task 1: (Priority: Low)
+
+Add Unsubscription Link in the Incident Notification Emails in SenIncidentNotification.ts. This will be similar as.
+
+```typescript
+// in EmailNotifier.ts
+const unsubscribeLink = data.unsubscribeUrl
+  ? `<br /><a href="${data.unsubscribeUrl}" style="color: #aaa; text-decoration: underline;">Unsubscribe from email alerts.</a>`
+  : '';
+```
+
+or
+
+```typescript
+// in EmailNotifier.ts
+// Generate unsubscribe URL if token is provided
+const unsubscribeUrl = unsubscribeToken
+  ? `${String(env.NEXT_PUBLIC_HOST)}/unsubscribe/${String(unsubscribeToken)}`
+  : undefined;
+
+// Define email options
+const mailOptions = {
+  from: env.EMAIL_FROM,
+  to: destination,
+  subject: subject,
+  html: getEmailTemplate({
+    content: mailBody,
+    subject: subject,
+    unsubscribeUrl: unsubscribeUrl,
+  }),
+};
+```
+
+Task 2: (Priority: High)
+
+If SiteIncident.reviewStatus = SiteIncidentReviewStatus.STOP_ALERTS,
+Then Stop Alerts related to that Incident.
+
+Task 3: (Priority: High)
+
+API to stop alerts for a specific incident.
+
+Task 4: (Priority: CRITICAL)
+
+I have updated the relation in the schema.prisma & generated the client types. all prisma site queries should use `siteIncidents` instead of `incidents`.
+
+---
+
+## Stop Alerts
+
+1. Update `CreateIncidentNotifications.ts`.
+
+(thought): If user is able to update the `reviewStatus`, that means we already have a `SiteIncident` & `Notificaiton` for `INCIDENT_START` which is linked to the incident via `SiteIncident.startNotificationId`.
+After we call the API to stop the alerts, we should update the `reviewStatus` to `STOP_ALERTS`.
+Base on this system will ignore Sending Notifications for `INCIDENT_END`.
+
+2. Update `CreateNotificaitons.ts`.
+
+(thought): CreateIncidentNotifications will take care of the Incident Notifications which we are sending via email, sms, whatsapp. But device, webhook notifications are handled by `CreateNotifications.ts`. If `SiteIncident.reviewStatus` is `STOP_ALERTS`, we should not send device, webhook notifications.
+To Stop that we must check `SiteIncident.reviewStatus` in `CreateNotifications.ts` and if it is `STOP_ALERTS`, we should not send device, webhook notifications. we need to update the `const unprocessedAlerts = await prisma.siteAlert.findMany({` query. But SiteIncident is fairly new feature so we might not find siteIncidentId for all the alerts. But since this is a CRON & Incidents are already published feature so the Entries already will have the siteIncidentId with them. So we need to be careful to call the keys if exists. Instead of using relational query, use simpler query I don't have much confidence on the query, so update the query select the `siteIncident.reviewStatus` field & Check if the the value is `STOP_ALERTS` (Ofcourse check with enum type so we do not miss any type issue) then skip creating the notification. If there are no such field or not matching value or any other issue, we should continue creating the notification.
+
+In both the files add a log (& only logs - do not update any response type - my automations are dependent on them) to indicate
+
+1. in case of `CreateIncidentNotifications.ts`, how many notifications are skipped for the `STOP_ALERTS` status, & for which alertMethod.
+2. in case of `CreateNotifications.ts`, how many notifications are skipped for the `STOP_ALERTS` status & for which alertMethod.
+
+---
+
+## Prisma Schema Update refactor
+
+```
+model Site {
+  ...
+    incidents      SiteIncident[]
+  ...
+}
+```
+
+to
+
+```
+model Site {
+  ...
+    siteIncidents      SiteIncident[]
+  ...
+}
+```
+
+Check all the queries involving site to figure out if there are anything to update or not.

--- a/apps/server/src/Services/Notifications/SendIncidentNotifications.ts
+++ b/apps/server/src/Services/Notifications/SendIncidentNotifications.ts
@@ -14,6 +14,7 @@ import type {NotificationParameters} from '../../Interfaces/NotificationParamete
 import {getLocalTime} from '../../../src/utils/date';
 import type DataRecord from '../../Interfaces/DataRecord';
 import {isSiteIncidentMethod} from './NotificationRoutingConfig';
+import {unsubscribeService} from '../AlertMethod/UnsubscribeService';
 
 type NotificationWithRelations = Notification & {
   siteAlert: SiteAlert & {
@@ -128,12 +129,41 @@ export class SendIncidentNotifications {
 
             const url = `https://firealert.plant-for-the-planet.org/incident/${incidentId}`;
 
+            // Generate unsubscribe token for email notifications
+            let unsubscribeToken: string | undefined;
+            if (alertMethod === NOTIFICATION_METHOD.EMAIL) {
+              try {
+                const alertMethodRecord = await prisma.alertMethod.findFirst({
+                  where: {
+                    destination: destination,
+                    method: 'email',
+                    isEnabled: true,
+                  },
+                });
+
+                if (alertMethodRecord) {
+                  unsubscribeToken = unsubscribeService.generateToken(
+                    alertMethodRecord.id,
+                    alertMethodRecord.userId,
+                  );
+                }
+              } catch (error) {
+                logger(
+                  `Failed to generate unsubscribe token for ${destination}: ${
+                    (error as Error).message
+                  }`,
+                  'warn',
+                );
+              }
+            }
+
             const params: NotificationParameters = {
               id: id,
               message: message,
               subject: subject,
               url: url,
               siteName: siteName,
+              unsubscribeToken: unsubscribeToken,
               alert: {
                 id: siteAlert.id,
                 type: siteAlert.type,

--- a/apps/server/src/Services/SiteIncident/SiteIncidentRepository.ts
+++ b/apps/server/src/Services/SiteIncident/SiteIncidentRepository.ts
@@ -1,4 +1,8 @@
-import {type PrismaClient, type SiteIncident} from '@prisma/client';
+import {
+  type PrismaClient,
+  type SiteIncident,
+  SiteIncidentReviewStatus,
+} from '@prisma/client';
 import {logger} from '../../server/logger';
 import {
   type CreateIncidentData,
@@ -101,7 +105,7 @@ export class SiteIncidentRepository {
           startedAt: data.startedAt,
           isActive: true,
           isProcessed: false,
-          reviewStatus: 'to_review',
+          reviewStatus: SiteIncidentReviewStatus.TO_REVIEW,
           siteAlerts: {
             connect: {
               id: data.startSiteAlertId,

--- a/apps/server/src/Services/SiteIncident/SiteIncidentService.ts
+++ b/apps/server/src/Services/SiteIncident/SiteIncidentService.ts
@@ -1,4 +1,8 @@
-import {type SiteAlert, type SiteIncident} from '@prisma/client';
+import {
+  type SiteAlert,
+  type SiteIncident,
+  SiteIncidentReviewStatus,
+} from '@prisma/client';
 import {logger} from '../../server/logger';
 import {
   type SiteIncidentInterface,
@@ -457,7 +461,7 @@ export class SiteIncidentService {
    */
   async updateReviewStatus(
     incidentId: string,
-    status: string,
+    status: SiteIncidentReviewStatus,
   ): Promise<SiteIncident> {
     // Validate inputs
     if (

--- a/apps/server/src/Services/SiteIncident/errors.ts
+++ b/apps/server/src/Services/SiteIncident/errors.ts
@@ -44,7 +44,7 @@ export class InvalidReviewStatusError extends TRPCError {
   constructor(status: string) {
     super({
       code: 'BAD_REQUEST',
-      message: `Invalid review status: ${status}. Must be one of: to_review, in_review, reviewed`,
+      message: `Invalid review status: ${status}. Must be one of: TO_REVIEW, STOP_ALERTS`,
     });
   }
 }

--- a/apps/server/src/server/api/zodSchemas/siteIncident.schema.ts
+++ b/apps/server/src/server/api/zodSchemas/siteIncident.schema.ts
@@ -1,13 +1,10 @@
 import {z} from 'zod';
+import {SiteIncidentReviewStatus} from '@prisma/client';
 
 /**
  * Schema for review status values
  */
-export const reviewStatusSchema = z.enum([
-  'to_review',
-  'in_review',
-  'reviewed',
-]);
+export const reviewStatusSchema = z.nativeEnum(SiteIncidentReviewStatus);
 
 /**
  * Schema for getting a single incident by ID

--- a/docs/fire-incident/features/Stop Alerts + Unsubscribe + ReviewStatus Alignment.md
+++ b/docs/fire-incident/features/Stop Alerts + Unsubscribe + ReviewStatus Alignment.md
@@ -1,0 +1,58 @@
+**Title:** Stop Alerts + Unsubscribe + ReviewStatus Alignment
+
+**Summary**
+
+- Suppress all future incident and siteAlert notifications when `reviewStatus = STOP_ALERTS`.
+- Add unsubscribe links for incident emails.
+- Align reviewStatus values across server, schema validation, and client types to Prisma enum.
+- Scan and update any Prisma `Site` relation usage from `incidents` to `siteIncidents` (none found so far).
+
+**Implementation Changes**
+
+- **Notification creation gating**
+  - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/Services/Notifications/CreateIncidentNotifications.ts`
+    - Import `SiteIncidentReviewStatus` from Prisma.
+    - When building the queue, skip any incident with `reviewStatus = STOP_ALERTS`.
+    - Count skipped notifications by method (email/sms/whatsapp) and log a single summary line at end.
+    - Still mark incidents as processed, so they won’t retry.
+  - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/Services/Notifications/CreateNotifications.ts`
+    - Extend `siteAlert.findMany` select to include `siteIncident { reviewStatus }`.
+    - If `siteIncident?.reviewStatus === STOP_ALERTS`, skip building notifications for that alert.
+    - Count skipped notifications by method (device/webhook) and log a summary line at end.
+    - Keep siteAlerts marked as processed (no API response changes).
+- **Unsubscribe link for incident emails**
+  - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/Services/Notifications/SendIncidentNotifications.ts`
+    - Add unsubscribe token generation for email notifications (mirror `SendNotifications.ts`).
+    - Pass `unsubscribeToken` into `NotificationParameters` so EmailNotifier renders the link.
+- **Stop-alert API via review status**
+  - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/server/api/zodSchemas/siteIncident.schema.ts`
+    - Replace custom string enum with `z.nativeEnum(SiteIncidentReviewStatus)` so `STOP_ALERTS` is accepted.
+  - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/server/api/routers/siteIncident.ts`
+    - Keep `updateIncidentReviewStatus` but allow `STOP_ALERTS` via updated schema.
+    - Continue permission checks as-is.
+- **ReviewStatus alignment to Prisma enum**
+  - Update server types and defaults to use Prisma enum values (`TO_REVIEW`, `STOP_ALERTS`).
+  - Update client type(s) that still expect lowercase values.
+  - Files likely touched:
+    - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/Interfaces/SiteIncident.ts`
+    - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/server/src/Services/SiteIncident/SiteIncidentRepository.ts`
+    - `/Volumes/WDSN5000/Plant-for-the-Planet/FireAlert.worktrees/wt-fire-incident/apps/nativeapp/app/types/incident.ts`
+- **Prisma `Site` relation refactor**
+  - Re-scan for `site.incidents` usage and replace with `site.siteIncidents` wherever present.
+  - Current repo scan found no references, so this is likely a no-op.
+
+**Test Plan**
+
+1. Create/identify a SiteIncident, set `reviewStatus = STOP_ALERTS`, run notification cron, verify:
+   - No new incident notifications created.
+   - No device/webhook notifications created for siteAlerts linked to that incident.
+   - Logs show skipped counts per method.
+2. Send an incident email and confirm the unsubscribe link appears and works.
+3. Call `updateIncidentReviewStatus` with `STOP_ALERTS` and confirm it persists.
+4. Sanity-check any client code that displays review status still renders correctly.
+
+**Assumptions**
+
+- `STOP_ALERTS` should suppress all future incident and siteAlert notifications tied to the incident.
+- The canonical review status values are Prisma’s enum values (`TO_REVIEW`, `STOP_ALERTS`).
+- No API response shapes will change; only logs are added.


### PR DESCRIPTION
- skip incident and site-alert notifications when reviewStatus is STOP_ALERTS and log skipped counts by method
- add unsubscribe token support for incident email notifications
- align reviewStatus typing/validation with Prisma SiteIncidentReviewStatus across server and native types
- add docs for stop-alerts, unsubscribe, and review-status alignment

@
