### PR TITLE
Fix Android OneSignal permission propagation

### DIFF
--- a/.claude/plans/notification-permission-fix.md
+++ b/.claude/plans/notification-permission-fix.md
@@ -1,0 +1,265 @@
+# Notification Permission Fix — Plan
+
+## Context
+
+Push notifications stopped working in production after the deep-linking PR
+(#331) shipped, even though email notifications still arrive and the mobile
+app records the device in our DB.
+
+OneSignal dashboard for player ID `b393b6e5-311f-40a5-98b4-274c5cb91c15`
+(a real test device, CMF Phone 2 Pro on Android 16) shows:
+
+- Status: **Never Subscribed**
+- Status details: **Permission Not Granted**
+- 7 sessions, first session 04/28, last session 04/29
+
+So the SDK is running on the device, but OneSignal has never observed a
+permission grant, so it has no push token and no subscription. The server's
+send call returns:
+
+```json
+{"id":"","errors":{"invalid_player_ids":["b393b6e5-..."]}}
+```
+
+…with HTTP 200, which our current server code treats as success. Two bugs
+combine to produce the observed silence: a mobile permission flow that
+doesn't reliably request or observe permission, and a server response check
+that swallows OneSignal's "no recipients reached" rejection.
+
+Local emulator testing previously masked the mobile bug because older Android
+emulators auto-granted notification permission. Android 13+ requires explicit
+`POST_NOTIFICATIONS` runtime grant.
+
+---
+
+## Root cause
+
+### Mobile — `apps/nativeapp/app/services/OneSignal/OneSignalStateManager.ts:78-80`
+
+```typescript
+OneSignal.initialize(appId);
+OneSignal.Notifications.requestPermission(false);
+OneSignal.login(userId);
+```
+
+Three problems on three lines:
+
+1. **`requestPermission` is fire-and-forget.** It returns `Promise<boolean>`
+   but is not awaited. The result is unobservable, and `login(userId)` can
+   race ahead of the SDK's permission state machine.
+2. **`fallbackToSettings = false`.** A user who denied once can never be
+   prompted again from inside the app — the SDK won't deep-link them to
+   system Settings to re-enable.
+3. **No permission-change listener.** When the user toggles notifications on
+   in Settings (which is how this user said they "allowed" it), the SDK has
+   no observer registered, so OneSignal's internal subscription state stays
+   at "Never Subscribed".
+
+There is also no explicit `OneSignal.User.pushSubscription.optIn()` call
+after a permission grant. v5 *should* auto-opt-in but doesn't reliably do so
+when permission was previously denied or when the listener wasn't registered
+in time.
+
+### Server — `apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts:96`
+
+```typescript
+if (!response.ok) { /* mark fail */ }
+return true;
+```
+
+Treats any HTTP 200 as success. OneSignal's API contract is more nuanced:
+
+| Response | Body shape | Meaning |
+|---|---|---|
+| 200 | `{"id":"<id>","recipients":N}` | Real success |
+| 200 | `{"id":"","errors":{"invalid_player_ids":[...]}}` | Total failure — zero recipients |
+| 200 | `{"id":"<id>","recipients":N,"errors":{"invalid_player_ids":[...]}}` | Partial — some delivered, some rejected |
+| 4xx/5xx | error body | API auth or rate limit failure |
+
+Cases 2 and 3 are silently treated as success today. `failCount` never
+increments, so the alertMethod is never disabled, and operators have no
+signal that delivery is broken.
+
+---
+
+## Changes
+
+### File 1: `apps/nativeapp/app/services/OneSignal/OneSignalStateManager.ts`
+
+Replace the body of `_performInitialization` so that:
+
+1. `initialize` runs first.
+2. `login` runs second (sets external ID).
+3. The `permissionChange` listener registers **before** any permission ask
+   so we never miss the grant event.
+4. The `pushSubscription.change` listener registers (existing behavior, kept).
+5. `getPermissionAsync()` reads current state.
+6. If permission is not yet granted → `requestPermission(true)` is awaited.
+   `true` enables fallback to Settings for previously-denied users.
+7. If `requestPermission` returns `true` (or permission was already granted),
+   `optIn()` is called explicitly to flip the OneSignal subscription.
+8. The `permissionChange` listener also calls `optIn()` on grant, so manual
+   permission changes via system Settings flip the subscription too.
+9. `permissionChange` dispatches a `permission_changed` event so
+   `OneSignalContext`'s subscriber can re-sync the device record on the
+   server.
+
+Add a `private handlePermissionChange` method to centralize the listener
+logic.
+
+### File 2: `apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts`
+
+Replace the `if (!response.ok)` block with a broader rejection check:
+
+```typescript
+const hasInvalidPlayers = !!responseBody?.errors?.invalid_player_ids?.length;
+const noneDelivered =
+  responseBody?.id === '' || responseBody?.recipients === 0;
+const oneSignalRejection = hasInvalidPlayers || noneDelivered;
+
+if (!response.ok || oneSignalRejection) {
+  // log specific reason, call handleFailedNotification, return false
+}
+```
+
+`handleFailedNotification` already exists and increments `failCount`. After
+`MAX_FAIL_COUNT[DEVICE] = 3` failures, the alertMethod is auto-disabled and
+the user is emailed (existing behavior, unchanged). On success,
+`SendNotifications.ts` already resets `failCount` to 0, so a recovered
+device returns to a clean slate naturally.
+
+---
+
+## Loop-safety review
+
+The plan introduces one new event listener (`permissionChange`) and one new
+explicit subscription mutation (`optIn()`). Walking each path:
+
+**Path A — fresh install, user grants permission:**
+1. `initialize` → `login` → listeners registered → `getPermissionAsync()`
+   returns `false` → `requestPermission(true)` awaits → user taps Allow.
+2. `permissionChange` listener fires with `true`.
+3. Listener calls `updateDeviceState()` (read-only OneSignal calls,
+   `setState` dispatches `state_updated`) and dispatches
+   `permission_changed`.
+4. Listener also calls `optIn()`. This triggers `pushSubscription.change`.
+5. Existing `pushSubscription.change` handler runs `updateDeviceState()` and
+   dispatches `subscription_changed`.
+6. `OneSignalContext` subscriber sees `permission_changed` then
+   `subscription_changed` → calls `performSync` twice. Internal
+   `syncCompleted` ref dedupes the second call (subscription_changed resets
+   the flag, but by then sync is already done; if sync is still running, the
+   second call is awaited concurrently — safe).
+
+No path causes a listener to re-trigger itself. `optIn()` does **not** fire
+`permissionChange`. `getPermissionAsync()` is read-only. `setState` only
+fires `state_updated`, which is not consumed for sync.
+
+**Path B — user denies permission, later allows via Settings:**
+1. `requestPermission(true)` returns `false`. No `optIn()` call.
+2. Later, user opens system Settings and toggles on.
+3. OneSignal's `permissionChange` listener fires with `true`.
+4. Same flow as Path A from step 3.
+
+**Path C — permission already granted at install (e.g., reinstall after
+previous grant):**
+1. `getPermissionAsync()` returns `true`.
+2. We skip `requestPermission` and call `optIn()` directly.
+3. `optIn()` triggers `pushSubscription.change`.
+4. Single sync. No permission event fires (state didn't change).
+
+**Path D — existing 5-second polling (`checkPermissions` in
+`OneSignalContext`):**
+- Polling reads OS permission and calls `setState({permission})` if changed.
+- `setState` dispatches `state_updated` only, not `permission_changed`.
+- `state_updated` does not trigger sync in `OneSignalContext`.
+- Polling is now redundant with the `permissionChange` listener but causes
+  no loop. Removal is **out of scope** for this PR (separate cleanup).
+
+**Path E — `optIn()` called when subscription already opted in:**
+- v5 docs say this is a no-op. No `subscription.change` event fires for
+  no-op state. Confirmed safe.
+
+**Path F — server `handleFailedNotification` cascades:**
+- After 3 device failures, the alertMethod is disabled (`isEnabled=false`).
+- `SendNotifications.ts` filters by `isEnabled=true`, so disabled methods
+  are not retried. No retry loop at the server level.
+
+No infinite loops in any path.
+
+---
+
+## Files modified
+
+| File | Approx lines changed |
+|---|---|
+| `apps/nativeapp/app/services/OneSignal/OneSignalStateManager.ts` | ~40 added/changed |
+| `apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts` | ~15 added/changed |
+
+No new dependencies. No DB migration. No native (Pods/gradle) changes.
+
+---
+
+## Out of scope
+
+- Removing the 5-second `checkPermissions` polling in `OneSignalContext`
+  (now redundant — separate cleanup PR).
+- Adding tests for the OneSignal state manager (no test scaffold for that
+  folder yet).
+- Touching `deviceSyncLogic.ts` — its `isEnabled = params.permission` is
+  correct once permission is reliably tracked.
+
+---
+
+## Verification (local-first)
+
+User testing setup:
+- Local server with production OneSignal credentials in `.env`
+- Local Postgres for FireAlert DB
+- Android 16 emulator (Pixel 10) **or** real CMF Phone 2 Pro (Android 16)
+
+### Steps
+
+1. **Uninstall the app from the emulator** (clears OS permission state and
+   any cached OneSignal subscription).
+2. Build and install fresh from this branch.
+3. On first launch, OS permission dialog should appear. Tap **Allow**.
+4. In OneSignal dashboard → search the new Subscription ID. Status should
+   change from "Never Subscribed" to **Subscribed** within seconds.
+5. Hit the local cron endpoint or seed a test alert. Server logs should
+   show `responseBody.id` populated (a real OneSignal notification ID, not
+   empty) and `recipients >= 1`.
+6. The push should land on the device.
+
+### Regression cases
+
+7. In Settings, toggle FireAlert notifications **off**. Trigger cron again.
+   Server should log `invalid_player_ids` failure (the new check) and
+   `failCount` should increment in the DB. Push does not arrive (expected).
+8. Toggle FireAlert notifications **back on** in Settings. The
+   `permissionChange` listener should fire, `optIn()` is called, OneSignal
+   re-subscribes the device. Trigger cron again — push arrives.
+9. Repeat the failure 3 times — alertMethod should auto-disable
+   (`isEnabled=false`) and the user should receive a fallback email
+   notification (existing behavior, just newly reachable).
+
+### Recommended Android version
+
+Android 16 emulator (Pixel 10) is correct — it matches the user's real
+device and exercises the Android 13+ runtime permission path which is where
+the bug lives. Older emulators (Android 12 and below) would not surface the
+bug because permission is auto-granted.
+
+---
+
+## Rollout notes
+
+- After merge, deploy server first (Vercel auto-deploys on develop merge).
+  The new failure detection becomes active immediately. Existing broken
+  installs will start incrementing `failCount` and will be auto-disabled
+  after 3 cron runs. They were already not receiving notifications, so this
+  is observability gain, not new breakage.
+- Mobile fix ships in the next TestFlight/Play track build. Users who
+  reinstall or update will have their permission flow corrected; on first
+  successful send `failCount` resets to 0 (existing logic in
+  `SendNotifications.ts`).

--- a/apps/nativeapp/android/app/src/main/AndroidManifest.xml
+++ b/apps/nativeapp/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
       android:name=".MainApplication"

--- a/apps/nativeapp/app/services/OneSignal/OneSignalStateManager.ts
+++ b/apps/nativeapp/app/services/OneSignal/OneSignalStateManager.ts
@@ -3,6 +3,7 @@
  * Manages OneSignal device state and lifecycle
  */
 
+import {AppState, type AppStateStatus, Platform} from 'react-native';
 import {OneSignal} from 'react-native-onesignal';
 import {DeviceState, StateChangeEvent, StateChangeListener} from './types';
 
@@ -20,10 +21,24 @@ interface InitializationStatus {
   completionTime?: number;
 }
 
+type PermissionChangeEvent = boolean | {permission?: boolean};
+type OneSignalUserChangeEvent = {current?: {externalId?: string | null}};
+
+const ANDROID_PERMISSION_PROPAGATION_RETRY_DELAYS_MS = [
+  1000, 2500, 4500,
+] as const;
+
 export class OneSignalStateManager {
   private state: DeviceState;
   private listeners: Set<StateChangeListener>;
   private initializationPromise: Promise<void> | null;
+  private listenersRegistered = false;
+  private androidPermissionSyncPromise: Promise<void> | null = null;
+  private androidPermissionRetryTimers: ReturnType<typeof setTimeout>[] = [];
+  private androidPermissionRetryRunId = 0;
+  private androidPermissionPropagationActive = false;
+  private androidPermissionPropagationAttemptInFlight = false;
+  private currentExternalUserId: string | null = null;
   private initializationStatus: InitializationStatus = {
     state: InitializationState.NOT_STARTED,
   };
@@ -59,8 +74,13 @@ export class OneSignalStateManager {
 
     try {
       await this.initializationPromise;
+      if (this.initializationStatus.state !== InitializationState.READY) {
+        throw (
+          this.initializationStatus.error ??
+          new Error('OneSignal initialization failed')
+        );
+      }
     } finally {
-      this.initializationStatus.state = InitializationState.NOT_STARTED;
       this.initializationPromise = null;
     }
   }
@@ -74,33 +94,43 @@ export class OneSignalStateManager {
         state: InitializationState.INITIALIZING,
         startTime: Date.now(),
       };
+      this.currentExternalUserId = userId;
 
       OneSignal.initialize(appId);
-      OneSignal.Notifications.requestPermission(false);
       OneSignal.login(userId);
+      this.registerEventListeners();
 
-      OneSignal.User.pushSubscription.addEventListener(
-        'change',
-        async _subscription => {
-          await this.updateDeviceState();
+      // Decide whether to prompt. Skip the prompt if the user has already
+      // answered (granted or denied) — Android 13+ won't re-prompt after a
+      // denial anyway, and re-prompting on every launch is bad UX.
+      const currentPermission =
+        await OneSignal.Notifications.getPermissionAsync();
 
-          const event = {
-            type: 'subscription_changed' as const,
-            previousState: {...this.state},
-            currentState: {...this.state},
-            timestamp: Date.now(),
-          };
-          this.listeners.forEach(listener => {
-            try {
-              listener(event);
-            } catch (_error) {
-              // Error in listener handled silently
-            }
-          });
-        },
-      );
+      if (!currentPermission) {
+        // fallbackToSettings = true so users who previously denied can be
+        // sent to system Settings via the SDK to re-enable.
+        const granted = await OneSignal.Notifications.requestPermission(true);
+        if (granted) {
+          await this.ensurePushSubscriptionAfterGrant(userId);
+        }
+      } else {
+        // OS permission already granted — make sure subscription is opted in.
+        OneSignal.User.pushSubscription.optIn();
+
+        if (Platform.OS === 'android') {
+          await this.ensureAndroidPermissionSync(userId);
+        }
+      }
 
       await this.updateDeviceState();
+
+      if (
+        Platform.OS === 'android' &&
+        this.state.permission &&
+        !this.hasFullyActivatedAndroidSubscription(userId)
+      ) {
+        this.startAndroidPermissionPropagation(userId);
+      }
 
       this.setState({isInitialized: true});
 
@@ -118,6 +148,33 @@ export class OneSignalStateManager {
       };
     }
   }
+
+  /**
+   * Handles OS-level permission changes (grants from settings, runtime
+   * prompt outcome, etc). On grant we explicitly opt the user in so the
+   * OneSignal subscription transitions from "Never Subscribed" to
+   * subscribed. Dispatches `permission_changed` so consumers (e.g. the
+   * device sync hook) can re-sync the server-side alertMethod record.
+   *
+   * Bound as an arrow-property so `this` is preserved when used as a
+   * listener callback.
+   */
+  private handlePermissionChange = async (
+    event: PermissionChangeEvent,
+  ): Promise<void> => {
+    const granted = this.normalizePermissionChange(event);
+    const previousState = {...this.state};
+
+    if (granted) {
+      await this.ensurePushSubscriptionAfterGrant(this.currentExternalUserId);
+    } else if (Platform.OS === 'android') {
+      this.stopAndroidPermissionPropagation();
+    }
+
+    await this.updateDeviceState();
+
+    this.emitStateChange('permission_changed', previousState);
+  };
 
   getState(): DeviceState {
     return {...this.state};
@@ -164,8 +221,233 @@ export class OneSignalStateManager {
     }
   }
 
+  private async ensurePushSubscriptionAfterGrant(
+    userId: string | null,
+  ): Promise<void> {
+    // On Android, the runtime permission grant can complete before OneSignal
+    // has fully attached the refreshed push subscription to the logged-in
+    // user. Replaying the settled state here prevents the "works only after
+    // reopening the app" symptom without affecting iOS behavior.
+    OneSignal.User.pushSubscription.optIn();
+
+    if (Platform.OS !== 'android' || !userId) {
+      return;
+    }
+
+    this.startAndroidPermissionPropagation(userId);
+    await this.ensureAndroidPermissionSync(userId);
+  }
+
+  private registerEventListeners(): void {
+    if (this.listenersRegistered) {
+      return;
+    }
+
+    // Register listeners BEFORE asking for permission so the grant event is
+    // never missed.
+    OneSignal.Notifications.addEventListener(
+      'permissionChange',
+      this.handlePermissionChange,
+    );
+
+    AppState.addEventListener('change', this.handleAppStateChange);
+    OneSignal.User.addEventListener('change', this.handleUserStateChange);
+
+    OneSignal.User.pushSubscription.addEventListener(
+      'change',
+      async _subscription => {
+        const previousState = {...this.state};
+        await this.updateDeviceState();
+        this.emitStateChange('subscription_changed', previousState);
+      },
+    );
+
+    this.listenersRegistered = true;
+  }
+
+  private handleUserStateChange = async (
+    event: OneSignalUserChangeEvent,
+  ): Promise<void> => {
+    if (
+      Platform.OS !== 'android' ||
+      !this.androidPermissionPropagationActive ||
+      !this.currentExternalUserId ||
+      event?.current?.externalId !== this.currentExternalUserId
+    ) {
+      return;
+    }
+
+    await this.ensureAndroidPermissionSync(this.currentExternalUserId);
+  };
+
+  private handleAppStateChange = async (
+    appState: AppStateStatus,
+  ): Promise<void> => {
+    if (
+      Platform.OS !== 'android' ||
+      appState !== 'active' ||
+      !this.androidPermissionPropagationActive ||
+      !this.currentExternalUserId
+    ) {
+      return;
+    }
+
+    await this.ensureAndroidPermissionSync(this.currentExternalUserId);
+  };
+
+  private normalizePermissionChange(event: PermissionChangeEvent): boolean {
+    if (typeof event === 'boolean') {
+      return event;
+    }
+
+    return event?.permission === true;
+  }
+
+  private emitStateChange(
+    type: StateChangeEvent['type'],
+    previousState: DeviceState,
+  ): void {
+    const event: StateChangeEvent = {
+      type,
+      previousState,
+      currentState: {...this.state},
+      timestamp: Date.now(),
+    };
+
+    this.listeners.forEach(listener => {
+      try {
+        listener(event);
+      } catch (_error) {
+        // Error in listener handled silently
+      }
+    });
+  }
+
+  private async ensureAndroidPermissionSync(userId: string): Promise<void> {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+
+    if (this.androidPermissionSyncPromise) {
+      return this.androidPermissionSyncPromise;
+    }
+
+    this.androidPermissionSyncPromise =
+      this.runAndroidPermissionPropagationAttempt(userId);
+
+    try {
+      await this.androidPermissionSyncPromise;
+    } finally {
+      this.androidPermissionSyncPromise = null;
+    }
+  }
+
+  private startAndroidPermissionPropagation(userId: string): void {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+
+    this.clearAndroidPermissionPropagationRetries();
+    this.androidPermissionRetryRunId += 1;
+    this.androidPermissionPropagationActive = true;
+    const runId = this.androidPermissionRetryRunId;
+    const stopDelayMs =
+      ANDROID_PERMISSION_PROPAGATION_RETRY_DELAYS_MS[
+        ANDROID_PERMISSION_PROPAGATION_RETRY_DELAYS_MS.length - 1
+      ] + 1500;
+
+    ANDROID_PERMISSION_PROPAGATION_RETRY_DELAYS_MS.forEach(delayMs => {
+      const timer = setTimeout(() => {
+        if (
+          runId !== this.androidPermissionRetryRunId ||
+          this.currentExternalUserId !== userId
+        ) {
+          return;
+        }
+
+        this.ensureAndroidPermissionSync(userId).catch(() => {
+          // Graceful error handling
+        });
+      }, delayMs);
+
+      this.androidPermissionRetryTimers.push(timer);
+    });
+
+    const stopTimer = setTimeout(() => {
+      if (runId === this.androidPermissionRetryRunId) {
+        this.stopAndroidPermissionPropagation();
+      }
+    }, stopDelayMs);
+
+    this.androidPermissionRetryTimers.push(stopTimer);
+  }
+
+  private clearAndroidPermissionPropagationRetries(): void {
+    this.androidPermissionRetryTimers.forEach(timer => clearTimeout(timer));
+    this.androidPermissionRetryTimers = [];
+  }
+
+  private stopAndroidPermissionPropagation(): void {
+    this.clearAndroidPermissionPropagationRetries();
+    this.androidPermissionPropagationActive = false;
+    this.androidPermissionRetryRunId += 1;
+  }
+
+  private async runAndroidPermissionPropagationAttempt(
+    userId: string,
+  ): Promise<void> {
+    if (
+      Platform.OS !== 'android' ||
+      this.androidPermissionPropagationAttemptInFlight
+    ) {
+      return;
+    }
+
+    const hasPermission = await this.safeOneSignalCall(
+      () => OneSignal.Notifications.getPermissionAsync(),
+      'getPermissionAsync',
+    );
+    if (!hasPermission || this.currentExternalUserId !== userId) {
+      return;
+    }
+
+    this.androidPermissionPropagationAttemptInFlight = true;
+
+    try {
+      // Replaying the same-session startup sequence is intentionally hacky
+      // but bounded. Reopen fixes the device because initialize/login runs
+      // again after Android permission is already granted. These nudges
+      // emulate that cold-start reconciliation inside the same session.
+      OneSignal.login(userId);
+      await this.sleep(300);
+      OneSignal.User.pushSubscription.optIn();
+      await this.sleep(300);
+      OneSignal.login(userId);
+      await this.sleep(300);
+      await this.updateDeviceState();
+    } finally {
+      this.androidPermissionPropagationAttemptInFlight = false;
+    }
+
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private hasFullyActivatedAndroidSubscription(userId: string): boolean {
+    return (
+      this.state.permission &&
+      this.state.externalId === userId &&
+      this.state.optedIn &&
+      !!this.state.pushToken &&
+      !!this.state.userId
+    );
+  }
+
   async handleLogin(userId: string): Promise<void> {
     try {
+      this.currentExternalUserId = userId;
       this.setState({
         userId: null,
         pushToken: null,
@@ -185,6 +467,8 @@ export class OneSignalStateManager {
 
   async handleLogout(): Promise<void> {
     try {
+      this.currentExternalUserId = null;
+      this.stopAndroidPermissionPropagation();
       this.setState({
         userId: null,
         pushToken: null,
@@ -210,6 +494,18 @@ export class OneSignalStateManager {
 
       if (permission !== previousPermission) {
         this.setState({permission});
+
+        if (
+          permission &&
+          Platform.OS === 'android' &&
+          this.currentExternalUserId
+        ) {
+          await this.ensurePushSubscriptionAfterGrant(
+            this.currentExternalUserId,
+          );
+        } else if (!permission && Platform.OS === 'android') {
+          this.stopAndroidPermissionPropagation();
+        }
       }
     } catch (_error) {
       // Graceful error handling

--- a/apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts
+++ b/apps/server/src/Services/Notifier/Notifier/DeviceNotifier.ts
@@ -6,6 +6,17 @@ import {logger} from '../../../server/logger';
 import {prisma} from '../../../server/db';
 import {handleFailedNotification as genericFailedNotificationHandler} from '../handleFailedNotification';
 
+// Subset of the OneSignal Create Notification response we rely on.
+// Full schema: https://documentation.onesignal.com/reference/create-notification
+type OneSignalNotificationResponse = {
+  id?: string;
+  recipients?: number;
+  errors?: {
+    invalid_player_ids?: string[];
+    [key: string]: unknown;
+  };
+};
+
 class DeviceNotifier implements Notifier {
   getSupportedMethods(): Array<string> {
     return [NOTIFICATION_METHOD.DEVICE];
@@ -34,8 +45,9 @@ class DeviceNotifier implements Notifier {
         'info',
       );
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       logger(
-        `Database Error: Couldn't modify the alertMethod or delete the notification: ${error}`,
+        `Database Error: Couldn't modify the alertMethod or delete the notification: ${errorMessage}`,
         'error',
       );
     }
@@ -87,16 +99,35 @@ class DeviceNotifier implements Notifier {
       body: JSON.stringify(payload),
     });
 
-    const responseBody = await response.json().catch(() => null);
+    const responseBody = (await response
+      .json()
+      .catch(() => null)) as OneSignalNotificationResponse | null;
     logger(
       `DeviceNotifier: OneSignal response status=${response.status}, body=${JSON.stringify(responseBody)}`,
       'debug',
     );
 
-    if (!response.ok) {
-      console.error(`[device-notifier] OneSignal rejected: status=${response.status} statusText="${response.statusText}" notificationId=${parameters.id} player_id=${destination} body=${JSON.stringify(responseBody)}`);
+    // OneSignal returns HTTP 200 even when zero recipients were reached
+    // (e.g. invalid_player_ids, unsubscribed devices). Treat those as
+    // failures so failCount increments and operators have observability.
+    const invalidPlayerIds = responseBody?.errors?.invalid_player_ids;
+    const hasInvalidPlayers = !!invalidPlayerIds?.length;
+    const noneDelivered =
+      responseBody?.id === '' || responseBody?.recipients === 0;
+    const oneSignalRejection = hasInvalidPlayers || noneDelivered;
+
+    if (!response.ok || oneSignalRejection) {
+      const reason = !response.ok
+        ? `HTTP ${response.status} ${response.statusText}`
+        : hasInvalidPlayers
+          ? `invalid_player_ids=${JSON.stringify(invalidPlayerIds)}`
+          : `noneDelivered (id="${responseBody?.id}", recipients=${responseBody?.recipients})`;
+
+      console.error(
+        `[device-notifier] OneSignal rejected: ${reason} notificationId=${parameters.id} player_id=${destination} body=${JSON.stringify(responseBody)}`,
+      );
       logger(
-        `Failed to send device notification. Error: ${response.statusText} for ${parameters.id}`,
+        `Failed to send device notification (${reason}) for ${parameters.id}`,
         'error',
       );
 


### PR DESCRIPTION
This PR fixes Android notification-permission propagation for OneSignal and hardens device push delivery handling.

What changed:
- Android app manifest now explicitly declares `POST_NOTIFICATIONS`.
- `OneSignalStateManager` now handles Android permission propagation more aggressively after grant, including retrying bounded same-session reconciliation when permission flips, and also triggering from the existing permission polling path.
- The Android retry flow no longer calls `logout()`, avoiding accidental transfer of the push subscription to a device-scoped anonymous user.
- OneSignal server delivery handling now treats HTTP 200 responses with `invalid_player_ids` or zero delivered recipients as failures instead of false positives, so device failures are surfaced properly.

@


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification permission requests on Android now follow proper runtime permission flow with improved state synchronization
  * Notification delivery failures are more accurately detected and reported by the server

* **Chores**
  * Updated Android app configuration to support notification permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->