### PR TITLE
fix: gate disabled alert-method buttons and repair Auth0 refresh-token flow

### DIFF
--- a/apps/nativeapp/app/api/axios/api.js
+++ b/apps/nativeapp/app/api/axios/api.js
@@ -2,11 +2,12 @@ import axios from 'axios';
 
 import ApiUrl from '../axios/url';
 import {Config} from '../../../config';
+import {refreshAccessToken} from '../../utils/auth';
 
 axios.defaults.timeout = 30000;
 
 // console.log('Config.API_URL', Config.API_URL);
-export default function fireApi({method, URL, data, header, token}) {
+export default async function fireApi({method, URL, data, header, token}) {
   const url = URL === ApiUrl.userDetails ? Config.API_URL + URL : URL;
   const verb = method?.toLowerCase();
 
@@ -14,44 +15,41 @@ export default function fireApi({method, URL, data, header, token}) {
     throw new Error(`Unsupported HTTP method: ${method}`);
   }
 
-  const baseHeaders = {
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Content-Type': 'application/json',
-    },
-  };
-
-  if (token) {
-    baseHeaders.headers.Authorization = `Bearer ${token}`;
-  }
-
-  const config = header || baseHeaders;
   const needsPayload = ['post', 'put', 'patch'].includes(verb);
 
-  const request = () =>
-    needsPayload ? axios[verb](url, data, config) : axios[verb](url, config);
+  const buildConfig = authToken => {
+    if (header) {
+      return header;
+    }
+    const config = {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      },
+    };
+    if (authToken) {
+      config.headers.Authorization = `Bearer ${authToken}`;
+    }
+    return config;
+  };
 
-  return request()
-    .then(response => {
-      // console.log('response', response);
-      return response;
-    })
-    .catch(error => {
-      if (error.response) {
-        // The request was made and the server responded with a status code, that falls out of the range of 2xx
-        // console.log(error.response.data);
-        // console.log(error.response.status);
-        // console.log(error.response.headers);
-      } else if (error.request) {
-        // The request was made but no response was received
-        // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-        // console.log(error.request);
-      } else {
-        // Something happened in setting up the request that triggered an Error
-        // console.log('Error', error.message);
+  const doRequest = authToken => {
+    const config = buildConfig(authToken);
+    return needsPayload
+      ? axios[verb](url, data, config)
+      : axios[verb](url, config);
+  };
+
+  try {
+    return await doRequest(token);
+  } catch (error) {
+    if (error?.response?.status === 401) {
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        return await doRequest(newToken);
       }
-      console.log('fireApi error', error.config);
-      console.log('fireApi error response', error.toJSON());
-      request();
-    });
+    }
+    console.log('fireApi error', error.config);
+    throw error;
+  }
 }

--- a/apps/nativeapp/app/redux/slices/login/loginSlice.ts
+++ b/apps/nativeapp/app/redux/slices/login/loginSlice.ts
@@ -10,6 +10,7 @@ interface LoginState {
   accessToken: string;
   userDetails: any;
   configData: any;
+  sessionExpired: boolean;
 }
 
 const initialState: LoginState = {
@@ -17,6 +18,7 @@ const initialState: LoginState = {
   accessToken: '',
   userDetails: null,
   configData: null,
+  sessionExpired: false,
 };
 
 export const loginSlice = createSlice({
@@ -35,6 +37,9 @@ export const loginSlice = createSlice({
     updateConfigData: (state, action: PayloadAction<any>) => {
       state.configData = action.payload;
     },
+    setSessionExpired: (state, action: PayloadAction<boolean>) => {
+      state.sessionExpired = action.payload;
+    },
   },
 });
 
@@ -43,6 +48,7 @@ export const {
   updateConfigData,
   updateAccessToken,
   updateUserDetails,
+  setSessionExpired,
 } = loginSlice.actions;
 export default loginSlice.reducer;
 

--- a/apps/nativeapp/app/routes/AppNavigator.tsx
+++ b/apps/nativeapp/app/routes/AppNavigator.tsx
@@ -137,7 +137,11 @@ export default function AppNavigator() {
           SplashScreen.hide();
         }
       } catch (err) {
-        await forceLogout();
+        try {
+          await forceLogout();
+        } finally {
+          SplashScreen.hide();
+        }
       }
     } else {
       SplashScreen.hide();

--- a/apps/nativeapp/app/routes/AppNavigator.tsx
+++ b/apps/nativeapp/app/routes/AppNavigator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {jwtDecode} from 'jwt-decode';
-import {useAuth0} from 'react-native-auth0';
+import {useToast} from 'react-native-toast-notifications';
 import NetInfo from '@react-native-community/netinfo';
 import SplashScreen from 'react-native-splash-screen';
 import {NavigationContainer} from '@react-navigation/native';
@@ -10,9 +10,11 @@ import {
   getUserDetails,
   updateIsLoggedIn,
   updateAccessToken,
+  setSessionExpired,
 } from '../redux/slices/login/loginSlice';
 import {CommonStack, SignInStack} from './stack';
-import {clearAll, getData, storeData} from '../utils/localStorage';
+import {getData} from '../utils/localStorage';
+import {refreshAccessToken, forceLogout} from '../utils/auth';
 import {useAppDispatch, useAppSelector} from '../hooks/redux/reduxHooks';
 import {OneSignalProvider} from '../hooks/notification/useOneSignal';
 import {
@@ -27,10 +29,12 @@ import {NotificationHandlers} from '../services/OneSignal';
 const onesignalAppId = Config.ONESIGNAL_APP_ID || '';
 
 export default function AppNavigator() {
-  const {isLoggedIn} = useAppSelector(state => state.loginSlice);
+  const {isLoggedIn, sessionExpired} = useAppSelector(
+    state => state.loginSlice,
+  );
   const dispatch = useAppDispatch();
   const queryClient = useQueryClient();
-  const {getCredentials, clearSession, clearCredentials} = useAuth0();
+  const toast = useToast();
 
   const notificationHandlers = React.useMemo<NotificationHandlers>(
     () => ({
@@ -62,6 +66,19 @@ export default function AppNavigator() {
     handleRefreshToken();
   }, [dispatch, queryClient]);
 
+  React.useEffect(() => {
+    if (!isLoggedIn) {
+      queryClient.clear();
+    }
+  }, [isLoggedIn, queryClient]);
+
+  React.useEffect(() => {
+    if (sessionExpired) {
+      toast.show('Session expired, please log in again', {type: 'danger'});
+      dispatch(setSessionExpired(false));
+    }
+  }, [sessionExpired, dispatch, toast]);
+
   function hasTimestampExpiredOrCloseToExpiry(timestamp: number) {
     // Convert timestamp to milliseconds
     timestamp *= 1000;
@@ -75,16 +92,6 @@ export default function AppNavigator() {
     // Check if the provided timestamp is within 5 hours of expiring or has already expired
     return timestamp - currentTime <= fiveHoursInMilliseconds;
   }
-
-  const refreshUserToken = async (refreshToken: string) => {
-    try {
-      const result = await getCredentials(refreshToken);
-      return result;
-    } catch (error) {
-      console.log('Error occured here', error);
-      return null;
-    }
-  };
 
   const checkInternetConnectivity = async () => {
     const netInfo = await NetInfo.fetch();
@@ -106,18 +113,12 @@ export default function AppNavigator() {
         }
         const isExpired = hasTimestampExpiredOrCloseToExpiry(decoded?.exp || 0);
         if (isExpired) {
-          if (!cred.refreshToken || cred.refreshToken == null) {
-            throw 'error';
+          const newAccessToken = await refreshAccessToken();
+          if (!newAccessToken) {
+            // refreshAccessToken() already forced a logout on failure
+            SplashScreen.hide();
+            return;
           }
-          const newAccessToken = await refreshUserToken(cred.refreshToken);
-          if (newAccessToken == null || !newAccessToken) {
-            throw 'error';
-          }
-          if (newAccessToken && !newAccessToken.refreshToken) {
-            throw 'error';
-          }
-          storeData('cred', newAccessToken);
-          dispatch(updateAccessToken(newAccessToken?.accessToken));
           const request = {
             onSuccess: () => {},
             onFail: () => {},
@@ -136,13 +137,7 @@ export default function AppNavigator() {
           SplashScreen.hide();
         }
       } catch (err) {
-        clearCredentials()
-          .then(() => clearSession({}, {useLegacyCallbackUrl: true}))
-          .then(async () => {
-            dispatch(updateIsLoggedIn(false));
-            queryClient.clear();
-            await clearAll();
-          });
+        await forceLogout();
       }
     } else {
       SplashScreen.hide();
@@ -150,7 +145,10 @@ export default function AppNavigator() {
   };
 
   return (
-    <NavigationContainer ref={navigationRef} linking={linking} onReady={flushPendingNotification}>
+    <NavigationContainer
+      ref={navigationRef}
+      linking={linking}
+      onReady={flushPendingNotification}>
       <OneSignalProvider appId={onesignalAppId} handlers={notificationHandlers}>
         {isLoggedIn ? <CommonStack /> : <SignInStack />}
       </OneSignalProvider>

--- a/apps/nativeapp/app/screens/Settings/Settings.tsx
+++ b/apps/nativeapp/app/screens/Settings/Settings.tsx
@@ -879,7 +879,10 @@ const Settings = () => {
                 <Text style={[styles.smallHeading]}>Email</Text>
                 {!alertMethods?.enabled.email && <DisabledBadge />}
               </View>
-              <TouchableOpacity onPress={handleAddEmail}>
+              <TouchableOpacity
+                disabled={!alertMethods?.enabled.email}
+                style={!alertMethods?.enabled.email && styles.addButtonDisabled}
+                onPress={handleAddEmail}>
                 <AddIcon />
               </TouchableOpacity>
             </View>
@@ -1026,7 +1029,10 @@ const Settings = () => {
                 <Text style={styles.smallHeading}>SMS</Text>
                 {!alertMethods?.enabled.sms && <DisabledBadge />}
               </View>
-              <TouchableOpacity onPress={handleAddSms}>
+              <TouchableOpacity
+                disabled={!alertMethods?.enabled.sms}
+                style={!alertMethods?.enabled.sms && styles.addButtonDisabled}
+                onPress={handleAddSms}>
                 <AddIcon />
               </TouchableOpacity>
             </View>
@@ -1106,7 +1112,10 @@ const Settings = () => {
                 <Text style={styles.smallHeading}>Webhook</Text>
                 {!alertMethods?.enabled.webhook && <DisabledBadge />}
               </View>
-              <TouchableOpacity onPress={handleWebhook}>
+              <TouchableOpacity
+                disabled={!alertMethods?.enabled.webhook}
+                style={!alertMethods?.enabled.webhook && styles.addButtonDisabled}
+                onPress={handleWebhook}>
                 <AddIcon />
               </TouchableOpacity>
             </View>
@@ -2013,6 +2022,9 @@ export const styles = StyleSheet.create({
   },
   btnDisabled: {
     opacity: 0.5,
+  },
+  addButtonDisabled: {
+    opacity: 0.4,
   },
   siteActionText: {
     marginLeft: 30,

--- a/apps/nativeapp/app/services/trpc.tsx
+++ b/apps/nativeapp/app/services/trpc.tsx
@@ -13,6 +13,7 @@ import {createAsyncStoragePersister} from '@tanstack/query-async-storage-persist
 import {Config} from '../../config';
 import {store} from '../redux/store';
 import {getCurrentVersion, versionToQueryParam} from '../utils/apiVersioning';
+import {refreshAccessToken} from '../utils/auth';
 import type {AppRouter} from '../../../server/src/server/api/root';
 
 export const trpc = createTRPCReact<AppRouter>();
@@ -20,6 +21,28 @@ export const trpc = createTRPCReact<AppRouter>();
 const asyncStoragePersister = createAsyncStoragePersister({
   storage: AsyncStorage,
 });
+
+async function fetchWithAuthRetry(
+  url: RequestInfo | URL,
+  init?: RequestInit,
+  retried = false,
+): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status === 401 && !retried) {
+    const newToken = await refreshAccessToken();
+    if (newToken) {
+      return fetchWithAuthRetry(
+        url,
+        {
+          ...init,
+          headers: {...init?.headers, authorization: `Bearer ${newToken}`},
+        },
+        true,
+      );
+    }
+  }
+  return res;
+}
 
 // console.log('Config.NEXT_API_URL', Config.NEXT_API_URL);
 export const createTRPCClientOptions: CreateTRPCClientOptions<AppRouter> = {
@@ -33,6 +56,7 @@ export const createTRPCClientOptions: CreateTRPCClientOptions<AppRouter> = {
           'x-api-version': getCurrentVersion(),
         };
       },
+      fetch: fetchWithAuthRetry as typeof fetch,
     }),
   ],
 };

--- a/apps/nativeapp/app/utils/auth.ts
+++ b/apps/nativeapp/app/utils/auth.ts
@@ -1,0 +1,59 @@
+import Auth0 from 'react-native-auth0';
+
+import {Config} from '../../config';
+import {store} from '../redux/store';
+import {
+  updateAccessToken,
+  updateIsLoggedIn,
+  setSessionExpired,
+} from '../redux/slices/login/loginSlice';
+import {storeData, clearAll} from './localStorage';
+
+const auth0 = new Auth0({
+  domain: Config.AUTH0_DOMAIN,
+  clientId: Config.AUTH0_CLIENT_ID,
+});
+
+let inFlightRefresh: Promise<string | null> | null = null;
+
+export async function forceLogout() {
+  try {
+    await auth0.credentialsManager.clearCredentials();
+    await auth0.webAuth.clearSession({}, {useLegacyCallbackUrl: true});
+  } finally {
+    store.dispatch(updateIsLoggedIn(false));
+    store.dispatch(setSessionExpired(true));
+    await clearAll();
+  }
+}
+
+export async function refreshAccessToken(): Promise<string | null> {
+  if (inFlightRefresh) {
+    return inFlightRefresh;
+  }
+
+  inFlightRefresh = (async () => {
+    try {
+      const creds = await auth0.credentialsManager.getCredentials(
+        undefined,
+        0,
+        {},
+        true,
+      );
+      if (!creds?.accessToken) {
+        throw new Error('no access token from refresh');
+      }
+      await storeData('cred', creds);
+      store.dispatch(updateAccessToken(creds.accessToken));
+      return creds.accessToken;
+    } catch (error) {
+      console.log('refreshAccessToken failed', error);
+      await forceLogout();
+      return null;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+}

--- a/apps/nativeapp/app/utils/auth.ts
+++ b/apps/nativeapp/app/utils/auth.ts
@@ -19,12 +19,18 @@ let inFlightRefresh: Promise<string | null> | null = null;
 export async function forceLogout() {
   try {
     await auth0.credentialsManager.clearCredentials();
-    await auth0.webAuth.clearSession({}, {useLegacyCallbackUrl: true});
-  } finally {
-    store.dispatch(updateIsLoggedIn(false));
-    store.dispatch(setSessionExpired(true));
-    await clearAll();
+  } catch (error) {
+    console.log('forceLogout: clearCredentials failed', error);
   }
+  try {
+    await auth0.webAuth.clearSession({}, {useLegacyCallbackUrl: true});
+  } catch (error) {
+    console.log('forceLogout: clearSession failed', error);
+  }
+  store.dispatch(updateIsLoggedIn(false));
+  store.dispatch(updateAccessToken(''));
+  store.dispatch(setSessionExpired(true));
+  await clearAll();
 }
 
 export async function refreshAccessToken(): Promise<string | null> {


### PR DESCRIPTION
## Summary
- Settings: SMS/Email/Webhook "+" buttons now respect the backend's `enabled` flag instead of only showing a disabled badge next to them
- Auth: fixed a broken `getCredentials()` call that was passing the refresh token into the SDK's `scope` parameter instead of letting it manage the refresh token internally
- Auth: added real 401 recovery for both the tRPC client and the axios wrapper, sharing a de-duped `refreshAccessToken()` utility so concurrent 401s don't trigger duplicate refreshes
- Auth: forced logouts now show a "Session expired, please log in again" toast instead of silently dropping to the Login screen

## Test plan
- [x] Toggled SMS/Email/Webhook enabled flags — "+" buttons dim and stop working, matching the existing badge/info text
- [x] Forced a real token refresh (bypassing the normal expiry check) — confirmed `getCredentials()` returns a valid new access token
- [x] Corrupted the in-memory access token mid-session and triggered a tRPC call — confirmed silent 401 → refresh → retry, no user-visible error, action completed successfully
- [x] Triggered a forced logout — confirmed toast shown and landed on Login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic access-token refresh and request retrying when sessions expire.
  * Added session-expiration notifications and automatic logout handling.
  * Added centralized session management for refreshing tokens and clearing account data.

* **Bug Fixes**
  * Improved handling of unauthorized API and data requests.
  * Cleared cached data when users log out.
  * Disabled alert-method buttons when the corresponding method is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->