### PR TITLE
feat(map): show fires and incidents for Protected Sites

### DIFF
--- a/.kiro/specs/protected-sites-map-fires-incidents/design.md
+++ b/.kiro/specs/protected-sites-map-fires-incidents/design.md
@@ -1,0 +1,119 @@
+# Design Document
+
+## Overview
+
+The map already has every rendering and interaction piece this feature needs. The only real gap is the read path: `alert.getAlerts` filters on `site.userId`, and Protected Sites have `userId = null` (ownership lives in `SiteRelation`). We add one new tRPC query for Protected Site alerts and merge its result into the alert list the map already consumes. Everything downstream (date filter, incident composition, bottom sheets, view switch) works unchanged because it operates on that list.
+
+## Current data flow (unchanged pieces)
+
+```
+alert.getAlerts ──► useFetchSites ──► alerts
+                                        │
+                    mapDurationDays ──► filteredAlerts (client-side date filter)
+                                        │
+              ┌─────────────────────────┴──────────────────────┐
+   alerts mode: renderAnnotations(true)              incidents mode: composedIncidents
+   fire icons (PointAnnotation + getFireIcon)        group by siteIncidentId, cap 60,
+   tap → openAlertDetails                            generateIncidentCircle
+                                                     tap → handleIncidentTap → openIncidentDetails
+```
+
+- `AlertDetailsBottomSheet` fetches via `alert.getAlert` (publicProcedure, no ownership check) — already works for Protected Site alerts.
+- `IncidentDetailsBottomSheet` fetches via `siteIncident.getIncident`; its `checkUserHasSitePermission` only rejects when `site.userId` is set and mismatched, so `userId = null` Protected Sites pass — already works.
+- The "further" navigation (incident detection → alert details → back) is Redux state in `detailsUISlice` and does not care where the alert came from.
+
+## Backend change
+
+### New query: `alert.getAlertsForProtectedSites`
+
+File: `apps/server/src/server/api/routers/alert.ts`
+
+A copy of `getAlerts` with one difference in the `site.findMany` where clause:
+
+```ts
+// getAlerts:
+where: { userId: userId, deletedAt: null, alerts: { some: {...} } }
+
+// getAlertsForProtectedSites:
+where: {
+  userId: null,
+  deletedAt: null,
+  siteRelations: { some: { userId: userId, deletedAt: null } },
+  alerts: { some: { eventDate: { gte: thirtyDaysAgo }, deletedAt: null } },
+}
+```
+
+Everything else identical: same select (including `site {id, name, project}` and `siteIncidentId`), same flatten, same sort, same 300 cap, same `getLocalTime` enrichment, same `{status: 'success', data}` envelope, same error handling.
+
+Notes:
+- `userId: null` guarantees no alert can appear in both endpoints, so the client merge needs no dedupe.
+- No input schema needed (no input), matching `getAlerts`.
+- `SiteRelation.isActive` is deliberately not filtered (decision: pause affects notifications only).
+
+## Frontend changes
+
+### 1. New hook: `useFetchProtectedSiteAlerts`
+
+File: `apps/nativeapp/app/utils/api.tsx`
+
+Mirror `useFetchSites`:
+
+```ts
+export const useFetchProtectedSiteAlerts = ({enabled, ...props}: UseQueryOptions) => {
+  const toast = useToast();
+  return trpc.alert.getAlertsForProtectedSites.useQuery(
+    ['alerts', 'getAlertsForProtectedSites'],
+    {
+      enabled,
+      retryDelay: 3000,
+      onError: () => {
+        toast.show('Something went wrong', {type: 'danger'});
+      },
+      ...props,
+    },
+  );
+};
+```
+
+### 2. Merge in `Home.tsx`
+
+File: `apps/nativeapp/app/screens/Home/Home.tsx`
+
+- Call the new hook next to `useFetchSites` (Home.tsx:260):
+
+```ts
+const {data: protectedSiteAlerts} = useFetchProtectedSiteAlerts({enabled: true});
+```
+
+- Extend the `filteredAlerts` memo (Home.tsx:294-300) to filter the concatenation of both sources:
+
+```ts
+const filteredAlerts = useMemo(() => {
+  const own = alerts?.json?.data ?? [];
+  const protectedArea = protectedSiteAlerts?.json?.data ?? [];
+  const all = own.concat(protectedArea);
+  if (all.length === 0) return [];
+  const cutoffDate = moment().subtract(mapDurationDays, 'days');
+  return all.filter(alert => moment(alert.eventDate).isAfter(cutoffDate));
+}, [alerts, protectedSiteAlerts, mapDurationDays]);
+```
+
+That is the entire frontend change. `renderAnnotations(true)` (fire icons, alerts mode), `composedIncidents` (incidents mode, 60 cap), `handleIncidentTap`, both bottom sheets, and the date filter all consume `filteredAlerts` and require no edits.
+
+## Why this respects the constraints
+
+- **No schema changes**: only a new resolver and a client merge.
+- **No breaking changes**: `getAlerts` untouched; older app versions never call the new endpoint; response shapes identical so every consumer of `filteredAlerts` sees the same alert object shape.
+- **Date filter**: applied client-side to the merged list, so both site types update instantly and identically.
+- **View switch**: `mapDisplayMode` guards are downstream of the merge and unchanged.
+- **Scope (map only)**: no other screen uses the new hook; `getAlerts` consumers elsewhere are unaffected.
+- **Independent failure**: if the new query errors, `filteredAlerts` still contains normal site alerts.
+
+## Pre-launch verification (done)
+
+Confirmed that Protected Sites in the database have `detectionGeometry` populated (PostGIS trigger in `docs/create-postgis-triggers.sql`) and existing SiteAlert / SiteIncident rows. If an environment ever misses this, the backfill is `UPDATE "Site" SET "geometry" = "geometry" WHERE "origin" = 'protectedarea';` to re-fire the trigger — a data fix, not a schema change.
+
+## Performance considerations
+
+- Worst case the map now holds up to 600 alerts (300 + 300) as `PointAnnotation`s. This matches the existing worst-case pattern; the incident view already caps at 60 circles. No new optimization needed for this feature.
+- The new query reuses the existing `SiteAlert` indexes; the `siteRelations` lookup uses the `SiteRelation` FK indexes.

--- a/.kiro/specs/protected-sites-map-fires-incidents/requirements.md
+++ b/.kiro/specs/protected-sites-map-fires-incidents/requirements.md
@@ -1,0 +1,67 @@
+# Requirements Document
+
+## Introduction
+
+The landing page Map View currently shows fire alerts (tappable fire icons) and incidents (tappable boundary circles) only for normal Sites, which are owned through `Site.userId`. Protected Sites are Sites with `origin = 'protectedarea'` linked to the user through `SiteRelation` (with `Site.userId = null`), so their SiteAlerts are never returned by `alert.getAlerts` and nothing fire-related renders for them.
+
+This feature shows fires and incidents for Protected Sites on the Map View, behaving the same as for normal Sites: fire icons respect the date filter (top left), incident boundaries appear in incidents mode, and both open the existing detail bottom sheets.
+
+## Constraints
+
+- No Prisma schema changes.
+- No breaking changes: existing endpoints keep their exact request and response shapes. All new behavior comes from one new tRPC endpoint and client-side merging.
+- SiteAlert and SiteIncident rows already exist for Protected Sites (confirmed: the PostGIS trigger populates `detectionGeometry` and `slices` for all Sites, and the alert pipeline does not filter by ownership).
+
+## Glossary
+
+- **Protected Site**: A `Site` row with `origin = 'protectedarea'`, `userId = null`, linked to users via `SiteRelation`
+- **SiteRelation**: Join table linking a user to a Protected Site, with `isActive` (notification pause) and `role`
+- **Date Filter**: The `MapDurationDropdown` (1d / 3d / 7d / 30d) on the top left of the map
+- **View Switch**: The `MapDisplayModeSwitcher` toggling between `alerts` and `incidents` display modes
+
+## Requirements
+
+### Requirement 1: Fetch fire alerts for Protected Sites
+
+**User Story:** As a user who follows Protected Sites, I want the app to load their fire alerts, so that I can see fires inside those areas.
+
+#### Acceptance Criteria
+
+1. THE Server SHALL provide a new tRPC query `alert.getAlertsForProtectedSites` (protectedProcedure, no input)
+2. THE endpoint SHALL return alerts for Sites linked to the calling user through an active `SiteRelation` (`deletedAt: null`), with `site.deletedAt: null`
+3. THE endpoint SHALL mirror `alert.getAlerts` exactly: 30-day event window, sorted newest first, capped at 300 alerts, same per-alert fields (`id, site {id, name, project}, siteIncidentId, eventDate, type, latitude, longitude, detectedBy, confidence, distance, data, localEventDate, localTimeZone`) and same `{status, data}` envelope
+4. THE endpoint SHALL return alerts regardless of `SiteRelation.isActive` (pause only affects notifications)
+5. THE existing `alert.getAlerts` endpoint SHALL remain unchanged
+
+### Requirement 2: Render fire icons for Protected Sites
+
+**User Story:** As a user, I want fire icons on the map inside my Protected Sites, so that fires there look the same as fires on my own sites.
+
+#### Acceptance Criteria
+
+1. WHEN the map is in `alerts` mode, THE App SHALL render Protected Site alerts as fire icons using the same rendering path as normal site alerts (`renderAnnotation`, `getFireIcon` age colors)
+2. WHEN the user changes the date filter, THE App SHALL filter Protected Site alerts by `eventDate` using the same client-side logic as normal site alerts, with no extra network request
+3. WHEN the user taps a Protected Site fire icon, THE App SHALL open the existing `AlertDetailsBottomSheet` via `openAlertDetails`
+4. THE fire icons for Protected Sites SHALL be visually identical to those for normal sites
+
+### Requirement 3: Render incidents for Protected Sites
+
+**User Story:** As a user, I want incident boundaries for fires inside my Protected Sites, so that I can inspect grouped fire events there.
+
+#### Acceptance Criteria
+
+1. WHEN the map is in `incidents` mode, THE App SHALL compose incidents from the merged alert list (normal plus protected) grouped by `siteIncidentId`, using the existing composition logic and its existing 60-incident cap
+2. WHEN the user taps a Protected Site incident boundary, THE App SHALL open the existing `IncidentDetailsBottomSheet` via `openIncidentDetails`
+3. WHEN the user taps a fire detection inside the incident sheet, THE App SHALL navigate to the alert details and back, using the existing flow
+4. THE incident boundaries for Protected Sites SHALL be visually identical to those for normal sites
+
+### Requirement 4: Scope and non-regression
+
+**User Story:** As a user of the current app, I want everything else to keep working exactly as before.
+
+#### Acceptance Criteria
+
+1. THE Protected Site alerts SHALL appear only on the Map View (fire icons, incident circles, and their bottom sheets); alert lists, counts, and notifications elsewhere SHALL be unchanged
+2. WHEN the user has no Protected Sites, THE map SHALL behave exactly as today
+3. IF the new query fails, THE App SHALL still render normal site alerts (the two sources fail independently)
+4. THE Protected Site boundary rendering (`renderProtectedAreasSource`) and its tap behavior SHALL remain unchanged

--- a/.kiro/specs/protected-sites-map-fires-incidents/tasks.md
+++ b/.kiro/specs/protected-sites-map-fires-incidents/tasks.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Protected Sites Map Fires and Incidents
+
+## Overview
+
+Show fire icons and incident boundaries for Protected Sites on the landing page Map View, identical in behavior to normal Sites. One new tRPC endpoint plus a client-side merge. No schema changes, no changes to existing endpoints.
+
+Branch: `feature/protected-sites-map-fires-incidents` (from `develop`)
+
+## Tasks
+
+- [ ] 1. Add `alert.getAlertsForProtectedSites` tRPC query
+
+  - Edit `apps/server/src/server/api/routers/alert.ts`
+  - Copy `getAlerts` and change the site where clause to `{userId: null, deletedAt: null, siteRelations: {some: {userId, deletedAt: null}}}`
+  - Keep 30-day window, newest-first sort, 300 cap, identical select and response envelope
+  - Do not filter on `SiteRelation.isActive`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 2. Add `useFetchProtectedSiteAlerts` hook
+
+  - Edit `apps/nativeapp/app/utils/api.tsx`
+  - Mirror `useFetchSites` with query key `['alerts', 'getAlertsForProtectedSites']`
+  - _Requirements: 2.1, 4.3_
+
+- [ ] 3. Merge protected site alerts into the map data flow
+
+  - Edit `apps/nativeapp/app/screens/Home/Home.tsx`
+  - Call the new hook next to `useFetchSites` (around line 260)
+  - Extend the `filteredAlerts` memo (around line 294) to concat both sources before the date cutoff filter, adding `protectedSiteAlerts` to the dependency array
+  - No changes to `renderAnnotations`, `composedIncidents`, `handleIncidentTap`, bottom sheets, `MapDurationDropdown`, or `MapDisplayModeSwitcher`
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 4. Manual verification (on request)
+
+  - Alerts mode: fire icons appear inside a Protected Site boundary, colors match age, tap opens `AlertDetailsBottomSheet`
+  - Date filter: switching 1d / 3d / 7d / 30d updates protected fires instantly with no refetch
+  - Incidents mode: circles appear for protected incidents, tap opens `IncidentDetailsBottomSheet`, detection tap navigates to alert details and back
+  - Regression: user with no Protected Sites sees identical behavior to develop; protected boundary tap still opens the site sheet
+  - _Requirements: 4.1, 4.2, 4.4_

--- a/apps/nativeapp/app/screens/Home/Home.tsx
+++ b/apps/nativeapp/app/screens/Home/Home.tsx
@@ -87,7 +87,7 @@ import {useIncidentData} from '../../hooks/incident/useIncidentData';
 import {trpc} from '../../services/trpc';
 import {Colors, Typography} from '../../styles';
 import type {IncidentCircleResult} from '../../types/incident';
-import {useFetchSites} from '../../utils/api';
+import {useFetchSites, useFetchProtectedSiteAlerts} from '../../utils/api';
 import handleLink from '../../utils/browserLinking';
 import {categorizedRes} from '../../utils/filters';
 import {getFireIcon} from '../../utils/getFireIcon';
@@ -259,6 +259,10 @@ const Home = ({navigation: _navigation, route}) => {
 
   const {data: alerts} = useFetchSites({enabled: true});
 
+  const {data: protectedSiteAlerts} = useFetchProtectedSiteAlerts({
+    enabled: true,
+  });
+
   // Fetch incident data when an alert with siteIncidentId is selected
   const {incident} = useIncidentData({
     incidentId: selectedAlert?.siteIncidentId,
@@ -290,14 +294,17 @@ const Home = ({navigation: _navigation, route}) => {
     [sites],
   );
 
-  // Filter alerts by duration
+  // Filter alerts by duration (own sites + protected sites)
   const filteredAlerts = useMemo(() => {
-    if (!alerts?.json?.data) return [];
+    const ownAlerts = alerts?.json?.data || [];
+    const protectedAlerts = protectedSiteAlerts?.json?.data || [];
+    const allAlerts = ownAlerts.concat(protectedAlerts);
+    if (allAlerts.length === 0) return [];
     const cutoffDate = moment().subtract(mapDurationDays, 'days');
-    return alerts.json.data.filter(alert =>
+    return allAlerts.filter(alert =>
       moment(alert.eventDate).isAfter(cutoffDate),
     );
-  }, [alerts, mapDurationDays]);
+  }, [alerts, protectedSiteAlerts, mapDurationDays]);
 
   // Compose incidents from filtered alerts
   const composedIncidents = useMemo(() => {

--- a/apps/nativeapp/app/utils/api.tsx
+++ b/apps/nativeapp/app/utils/api.tsx
@@ -15,3 +15,22 @@ export const useFetchSites = ({enabled, ...props}: UseQueryOptions) => {
   });
   return data;
 };
+
+export const useFetchProtectedSiteAlerts = ({
+  enabled,
+  ...props
+}: UseQueryOptions) => {
+  const toast = useToast();
+  const data = trpc.alert.getAlertsForProtectedSites.useQuery(
+    ['alerts', 'getAlertsForProtectedSites'],
+    {
+      enabled,
+      retryDelay: 3000, // Delay between retry attempts in milliseconds
+      onError: () => {
+        toast.show('Something went wrong', {type: 'danger'});
+      },
+      ...props,
+    },
+  );
+  return data;
+};

--- a/apps/server/src/server/api/routers/alert.ts
+++ b/apps/server/src/server/api/routers/alert.ts
@@ -97,6 +97,102 @@ export const alertRouter = createTRPCRouter({
     }
   }),
 
+  getAlertsForProtectedSites: protectedProcedure.query(async ({ctx}) => {
+    try {
+      const userId = ctx.user!.id;
+      const thirtyDaysAgo = subtractDays(new Date(), 30);
+      const sitesWithAlerts = await ctx.prisma.site.findMany({
+        where: {
+          userId: null,
+          deletedAt: null,
+          siteRelations: {
+            some: {
+              userId: userId,
+              deletedAt: null,
+            },
+          },
+          alerts: {
+            some: {
+              eventDate: {
+                gte: thirtyDaysAgo,
+              },
+              deletedAt: null,
+            },
+          },
+        },
+        select: {
+          alerts: {
+            select: {
+              id: true,
+              site: {
+                select: {
+                  id: true,
+                  name: true,
+                  project: {
+                    select: {
+                      id: true,
+                      name: true,
+                    },
+                  },
+                },
+              },
+              siteIncidentId: true,
+              eventDate: true,
+              type: true,
+              latitude: true,
+              longitude: true,
+              detectedBy: true,
+              confidence: true,
+              distance: true,
+              data: true,
+            },
+            where: {
+              eventDate: {
+                gte: thirtyDaysAgo,
+              },
+              deletedAt: null,
+            },
+          },
+        },
+      });
+      // Flatten the array of site alerts and sort by date
+      let alertsForUser = sitesWithAlerts.flatMap(site => site.alerts);
+      alertsForUser.sort(
+        (a, b) => b.eventDate.getTime() - a.eventDate.getTime(),
+      ); // Sort by date in descending order
+
+      // Limit to 300 most recent alerts
+      alertsForUser = alertsForUser.slice(0, 300);
+
+      const returnAlertsForUser = alertsForUser.map(alert => {
+        const localTime = getLocalTime(
+          alert.eventDate,
+          alert.latitude.toString(),
+          alert.longitude.toString(),
+        );
+        return {
+          ...alert,
+          localEventDate: localTime.localDate,
+          localTimeZone: localTime.timeZone,
+        };
+      });
+      return {
+        status: 'success',
+        data: returnAlertsForUser,
+      };
+    } catch (error) {
+      if (error instanceof TRPCError) {
+        // if the error is already a TRPCError, just re-throw it
+        throw error;
+      }
+      // if it's a different type of error, throw a new TRPCError
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `Something Went Wrong`,
+      });
+    }
+  }),
+
   getAlert: publicProcedure
     .input(queryAlertSchema)
     .query(async ({ctx, input}) => {


### PR DESCRIPTION
## Summary
- Protected Sites are `Site` rows linked via `SiteRelation` (`Site.userId = null`), so `alert.getAlerts` (filtered on `Site.userId`) never returned their fire alerts, and the map showed no fire icons or incident boundaries for them.
- Adds a new `alert.getAlertsForProtectedSites` tRPC query mirroring `alert.getAlerts` exactly (30-day window, 300 cap, same fields/envelope), resolving sites through `SiteRelation` instead of `userId`. `getAlerts` is untouched.
- Merges the new alert list into the map's existing `filteredAlerts` flow in `Home.tsx`, so the date filter, fire icons, incident composition, incident tap, alert tap, and the alerts/incidents view switch all work for Protected Sites exactly as they do for normal sites — no changes needed to that downstream rendering code.
- No schema changes. No changes to existing endpoint behavior.

Spec: `.kiro/specs/protected-sites-map-fires-incidents/` (requirements, design, tasks).

## Test plan
- [ ] Alerts mode: fire icons appear inside a Protected Site boundary, colored by age, tap opens the alert details sheet
- [ ] Date filter (1d/3d/7d/30d): Protected Site fires update instantly, same as normal sites
- [ ] Incidents mode: incident circles appear for Protected Sites, tap opens incident details, tapping a detection navigates to alert details and back
- [ ] Regression: user with no Protected Sites sees identical behavior to `develop`
- [ ] Regression: tapping a Protected Site's own boundary still opens the site info sheet (unchanged code path)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Map View now displays fire alerts from Protected Sites alongside alerts from your own sites.
  - Protected Site alerts support existing date filters, alert details, and map interaction behavior.
  - Incident boundaries now include incidents associated with Protected Sites.
  - Existing Protected Areas rendering and navigation remain unchanged.

- **Bug Fixes**
  - Normal site alerts continue to display if Protected Site alert data cannot be loaded.
  - Map behavior remains unchanged for users without Protected Sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->