### PR TITLE
fix: db-cleanup cron never advances its cutoff date on long-running deployments

### DIFF
--- a/apps/server/src/pages/api/cron/db-cleanup.ts
+++ b/apps/server/src/pages/api/cron/db-cleanup.ts
@@ -14,7 +14,7 @@ export const config = {
 const MAX_DURATION = config.maxDuration * 1000 - 20000;
 
 // Set up a uniform time to be 1 AM for cleanup reference
-const currentDateTimeAt1AM = new Date();
+let currentDateTimeAt1AM = new Date();
 currentDateTimeAt1AM.setHours(1, 0, 0, 0); // Set time to 1:00 AM of today
 
 function shouldContinueDeletion(
@@ -388,16 +388,18 @@ async function cleanNotifications(startTime: number) {
 
   // Use continueDeletion patterns like the above functions
   let continueDeletion = true;
+  const ninetyDaysAgo = new Date(
+    currentDateTimeAt1AM.getTime() - 90 * 24 * 60 * 60 * 1000,
+  );
   while (continueDeletion) {
-    // Delete Notifications which have sentAt Older than 90 Days (if NULL Do not delete)
+    // Delete Notifications which have sentAt Older than 90 Days (if NULL Do not delete),
+    // or which were skipped (failed to send, so sentAt never gets set) and are older than 90 Days
     const notificationsToDelete = await prisma.notification.findMany({
       where: {
-        sentAt: {
-          not: null,
-          lt: new Date(
-            currentDateTimeAt1AM.getTime() - 90 * 24 * 60 * 60 * 1000,
-          ),
-        },
+        OR: [
+          {sentAt: {not: null, lt: ninetyDaysAgo}},
+          {isSkipped: true, sentAt: null, createdAt: {lt: ninetyDaysAgo}},
+        ],
       },
       take: batchSize,
       select: {id: true},
@@ -441,6 +443,10 @@ export default async function dbCleanup(
       return;
     }
   }
+  // Recompute "now" fresh for every request — see note on the module-level declaration above.
+  currentDateTimeAt1AM = new Date();
+  currentDateTimeAt1AM.setHours(1, 0, 0, 0);
+
   const startTime = Date.now();
   // What is to be cleaned
   const validCleanupOptions = [


### PR DESCRIPTION
## Issue & Finding

Production observability showed the daily DB cleanup cron (`db-cleanup.ts`, triggered every 6 hours by an n8n workflow) reporting `Deleted 0 ...` for notifications, users, sites, and alert methods, consistently, for months.

Cross-checking the cumulative `Stats` table against direct SQL against production confirmed this wasn't "nothing to clean":

| Metric | Stats `lastUpdated` |
|---|---|
| `notifications_deleted` | 2026-05-05 |
| `users_deleted` | 2026-05-05 |
| `sites_deleted` | 2026-04-16 |
| `siteAlerts_deleted` | 2026-03-09 |

`geoEvents_deleted` (frozen since 2024-08-26) is a red herring — a separate n8n automation already purges `GeoEvent` rows older than 5 days directly via SQL every 30 minutes, so the app's own 30-day sweep never finds anything. Not a bug.

## Root Cause

`currentDateTimeAt1AM` was declared as a **module-level `const`**:

```ts
const currentDateTimeAt1AM = new Date();
currentDateTimeAt1AM.setHours(1, 0, 0, 0);
```

Every retention threshold (7/30/90 days) in this file is derived from this single value. Node.js only executes a module's top-level code once per process — the first time it's loaded — not once per request.

### Scenario: Coolify (long-running process)

The cron endpoint is served from Coolify, which runs this app as a persistent Node.js server (not ephemeral serverless functions). The module loads once when the container boots, computing `currentDateTimeAt1AM` at that exact moment. It never gets recomputed again for the lifetime of that container, no matter how many requests it serves afterward.

### Scenario: n8n (the caller)

n8n calls `/api/cron/db-cleanup?clean=...` every 6 hours, and this is the part that's easy to misread: n8n calling the endpoint repeatedly does **not** cause the module to reload. Each call just invokes the already-loaded `dbCleanup` handler function again — the top-level `const currentDateTimeAt1AM = ...` line sits outside that function, so it's never re-executed by a request, only by an actual process restart/redeploy.

### Why this produced exactly what we saw

Right after a container boot, the cutoffs (boot time minus 7/30/90 days) are valid, so the first runs clear out whatever backlog exists at that moment — explaining the large cumulative counts in `Stats`. After that, the cutoff is frozen while real data keeps getting newer, so nothing new can ever be "older than" a threshold that stopped moving. The math confirms this precisely: the oldest remaining `Notification.sentAt` in production is `2026-02-04`, and `2026-02-04 + 90 days = 2026-05-05` — exactly when both `notifications_deleted` and `users_deleted` stopped updating, in the same cron run.

## Current Fix

**What changes:** `currentDateTimeAt1AM` is now a `let`, reassigned at the very top of the `dbCleanup` request handler on every invocation, instead of being computed once at module load.

**How it fixes it:** every one of the six cleanup functions (`deleteGeoEventsBatch`, `deleteVerificationRequests`, `cleanUsers`, `cleanSites`, `cleanAlertMethods`, `cleanNotifications`) reads `currentDateTimeAt1AM` as a closure over this module-scope variable — none of them needed to change. Since they're only ever called from inside `dbCleanup`, after the reassignment, they automatically pick up a correctly fresh "now" on every request:
- On Coolify: each incoming request now recomputes the date, independent of how long the process has been running.
- On Vercel (serverless): unaffected — it already got a fresh module load per invocation, this doesn't change that behavior.

**Secondary fix, same file:** `cleanNotifications` only deleted notifications where `sentAt` was set and 90+ days old. Failed/skipped sends set `isSkipped: true` and never set `sentAt`, so they were never caught and accumulated indefinitely (497,897 skipped notifications in production, 80,114 already 90+ days old by `createdAt`). Added a second condition (`isSkipped: true AND sentAt IS NULL AND createdAt` 90+ days old) alongside the existing check.

## Next Steps

- Deploy and confirm the next few cron runs on Coolify report non-zero `Deleted X ...` counts and the `Stats` table starts advancing again.
- Given the backlog size (1.2M+ notifications, ~10 users plus their cascaded sites/alerts), expect the first several runs to take longer than usual while draining it in 1000-row batches under the existing watchdog timer.
- Separately investigate why the `site` cleanup type never appears in cron logs even though it's configured in the n8n workflow's table list — may be hitting the `SiteIncident.startSiteAlertId`/`latestSiteAlertId` `ON DELETE RESTRICT` foreign key when a soft-deleted site's alerts are still referenced by an incident (not addressed in this PR).
- Consider whether Coolify's deployment should be restarted/redeployed after this fix ships, so the first post-fix run starts from a true "now" rather than waiting for the next natural restart.